### PR TITLE
feat(phase-9): Cilium CNI migration — FluxCD adoption + Hubble UI

### DIFF
--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,12 +4,12 @@ milestone: v2.5.1
 milestone_name: milestone
 status: verifying
 stopped_at: Completed 08-02-PLAN.md (nodeAffinity for all 8 apps and Prometheus)
-last_updated: "2026-04-06T10:29:00.148Z"
+last_updated: "2026-04-09T07:11:18.604Z"
 progress:
   total_phases: 12
   completed_phases: 7
-  total_plans: 17
-  completed_plans: 17
+  total_plans: 20
+  completed_plans: 19
 ---
 
 # Project State
@@ -19,7 +19,7 @@ progress:
 See: .planning/PROJECT.md (updated 2026-04-04)
 
 **Core value:** Every stateful app survives any single node failure without data loss
-**Current focus:** Phase 08 — balance-workloads-to-worker-nodes
+**Current focus:** Phase 09 — cilium-cni-migration
 **Milestone:** v1 — Cluster Hardening & Resilience
 
 ## Current Phase

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,12 +4,12 @@ milestone: v2.5.1
 milestone_name: milestone
 status: verifying
 stopped_at: Completed 08-02-PLAN.md (nodeAffinity for all 8 apps and Prometheus)
-last_updated: "2026-04-09T07:11:18.604Z"
+last_updated: "2026-04-09T07:15:06.257Z"
 progress:
   total_phases: 12
-  completed_phases: 7
+  completed_phases: 8
   total_plans: 20
-  completed_plans: 19
+  completed_plans: 20
 ---
 
 # Project State

--- a/.planning/phases/09-cilium-cni-migration/09-01-SUMMARY.md
+++ b/.planning/phases/09-cilium-cni-migration/09-01-SUMMARY.md
@@ -1,0 +1,23 @@
+---
+plan: 09-01
+phase: 09-cilium-cni-migration
+status: complete
+completed: 2026-04-09
+---
+
+## Summary
+
+Disabled Flannel CNI on all 3 nodes and opened the maintenance window for Cilium installation.
+
+## Tasks Completed
+
+1. **Pre-migration baseline confirmed** — All 3 nodes Ready, 3 flux-system NetworkPolicies present, BPF mounted, flannel.1 existed
+2. **K3s config updated and nodes restarted** — Appended `flannel-backend: none` and `disable-network-policy: true` to `/etc/rancher/k3s/config.yaml` on control-plane; restarted k3s on control-plane and k3s-agent on both workers; deleted flannel.1 on all 3 nodes (control-plane + workers had it)
+
+## Deviations
+
+- Plan said to delete flannel.1 only on control-plane; workers also had flannel.1 — deleted on all 3 (required for Cilium vxlan to work without address conflict)
+
+## Outcome
+
+All 3 nodes in NotReady state with no active CNI. flannel.1 interface deleted on all nodes. Ready for Plan 02.

--- a/.planning/phases/09-cilium-cni-migration/09-02-SUMMARY.md
+++ b/.planning/phases/09-cilium-cni-migration/09-02-SUMMARY.md
@@ -1,0 +1,26 @@
+---
+plan: 09-02
+phase: 09-cilium-cni-migration
+status: complete
+completed: 2026-04-09
+---
+
+## Summary
+
+Installed Cilium 1.16.19 via helm, restored all 3 nodes to Ready, installed cilium CLI, and restarted all pods to use Cilium networking.
+
+## Tasks Completed
+
+1. **Cilium installed** — `helm install cilium cilium/cilium --version 1.16.19` with K3s-specific values (k8sServiceHost: 127.0.0.1:6444, ipam CIDR 10.42.0.0/16, operator.replicas=1, hubble+relay+ui enabled). cilium-operator, hubble-relay, hubble-ui all Running.
+2. **All pods restarted** — Rolling restart of all Deployments, StatefulSets, and non-Cilium DaemonSets. Longhorn volumes force-recovered after stale mounts blocked reattachment.
+
+## Deviations
+
+- Workers had stale `flannel.1` interfaces (not just control-plane) — deleted before Cilium could start
+- Workers had stale `cilium_vxlan` interface conflicts — deleted crashing pods after flannel.1 removal resolved it
+- Longhorn volumes got stuck in `detaching/faulted` state due to K3s-agent restart killing instance managers — resolved by force-patching volume status and clearing stale kubelet mounts on worker-01
+- cilium CLI v0.19.2 installed (latest stable)
+
+## Outcome
+
+`cilium status`: Cilium OK, Operator OK, Envoy OK, Hubble Relay OK. All 3 nodes Ready. flux-system NetworkPolicies (3) intact. Both CNPG clusters healthy. All cloudflared pods Running. Longhorn volumes recovering (data safe — control-plane replicas were healthy throughout).

--- a/.planning/phases/09-cilium-cni-migration/09-03-SUMMARY.md
+++ b/.planning/phases/09-cilium-cni-migration/09-03-SUMMARY.md
@@ -1,0 +1,26 @@
+---
+plan: 09-03
+phase: 09-cilium-cni-migration
+status: complete
+completed: 2026-04-09
+---
+
+## Summary
+
+Created FluxCD GitOps manifests for Cilium CNI and opened PR for merge.
+
+## Tasks Completed
+
+1. **Base manifests created** — `infrastructure/controllers/base/cilium/` with repository.yaml (HelmRepository pointing to helm.cilium.io in flux-system), release.yaml (HelmRelease cilium 1.16.19 in kube-system with K3s-specific values and Hubble enabled), kustomization.yaml. Updated base/kustomization.yaml to include cilium.
+2. **Staging overlay created** — `infrastructure/controllers/staging/cilium/` with ingress.yaml (Traefik Ingress for Hubble UI at hubble.watarystack.org with cert-manager TLS) and kustomization.yaml. Updated staging/kustomization.yaml to include cilium.
+3. **Homepage updated** — Added Hubble entry to `apps/base/homepage/homepage-configmap.yaml` with href https://hubble.watarystack.org and cilium.png icon.
+4. **Branch and PR** — Committed all files to `feat/phase-9-cilium-cni-migration`, pushed, and opened PR #54.
+
+## Deviations
+
+- No namespace.yaml created for base/cilium (kube-system is built-in — diverges from Longhorn pattern intentionally to avoid reconciliation warnings)
+- HelmRepository namespace is flux-system (not kube-system) — required for cross-namespace HelmRelease sourceRef
+
+## Outcome
+
+PR santiagobermudezparra/HomeLab-Pro#54 open targeting main. After merge, FluxCD will reconcile and adopt the existing Cilium helm release (no re-install). Hubble UI will be accessible at hubble.watarystack.org once cert-manager issues TLS.

--- a/.planning/phases/09-cilium-cni-migration/09-VERIFICATION.md
+++ b/.planning/phases/09-cilium-cni-migration/09-VERIFICATION.md
@@ -1,0 +1,133 @@
+---
+phase: 09-cilium-cni-migration
+verified: 2026-04-09T08:00:00Z
+status: passed
+score: 5/5 must-haves verified
+re_verification: false
+gaps: []
+human_verification:
+  - test: "Confirm FluxCD adopts the existing Cilium HelmRelease after PR #54 merges"
+    expected: "kubectl get helmrelease -n kube-system cilium shows Reconciled=True with no re-install triggered"
+    why_human: "FluxCD adoption of an imperatively-installed Helm release cannot be verified without a running cluster"
+  - test: "Browse to https://hubble.watarystack.org and confirm Hubble UI loads"
+    expected: "Hubble UI renders network flows; cert-manager has issued a valid TLS certificate"
+    why_human: "Requires a running cluster with Traefik, cert-manager, and DNS resolving hubble.watarystack.org"
+---
+
+# Phase 9: Cilium CNI Migration Verification Report
+
+**Phase Goal:** Migrate the K3s cluster from Flannel to Cilium CNI. Replace the default Flannel CNI with Cilium 1.16.19 for eBPF-based networking, network policy enforcement, and Hubble observability. Bring the installation under GitOps control via FluxCD.
+**Verified:** 2026-04-09T08:00:00Z
+**Status:** passed
+**Re-verification:** No — initial verification
+
+---
+
+## Goal Achievement
+
+Plans 09-01 and 09-02 were imperative cluster operations (disabling Flannel, bootstrapping Cilium during a maintenance window). Their SUMMARYs confirm completion; no git artifacts exist for them. Verification scope is the git artifacts committed by Plan 09-03, which is the only plan that brings the installation under GitOps control.
+
+### Observable Truths
+
+| # | Truth | Status | Evidence |
+|---|-------|--------|----------|
+| 1 | FluxCD HelmRelease for Cilium committed to git | VERIFIED | `infrastructure/controllers/base/cilium/release.yaml` exists; `kind: HelmRelease`, `name: cilium`, `namespace: kube-system`, `version: "1.16.19"` |
+| 2 | Hubble UI accessible at hubble.watarystack.org via Traefik Ingress with TLS | VERIFIED (git artifacts) | `infrastructure/controllers/staging/cilium/ingress.yaml` exists; `host: hubble.watarystack.org`, `ingressClassName: traefik`, `cert-manager.io/cluster-issuer: letsencrypt-cloudflare-prod` — runtime accessibility needs human check |
+| 3 | Hubble UI appears on the Homepage dashboard | VERIFIED | `apps/base/homepage/homepage-configmap.yaml` lines 57-60 contain `- Hubble:` with `href: https://hubble.watarystack.org` and `icon: cilium.png` |
+| 4 | cilium directories exist in infrastructure/controllers/ | VERIFIED | `infrastructure/controllers/base/cilium/` contains repository.yaml, release.yaml, kustomization.yaml; `infrastructure/controllers/staging/cilium/` contains ingress.yaml, kustomization.yaml |
+| 5 | base/kustomization.yaml and staging/kustomization.yaml both include cilium | VERIFIED | `infrastructure/controllers/base/kustomization.yaml` line 7: `- cilium`; `infrastructure/controllers/staging/kustomization.yaml` line 8: `- cilium` |
+
+**Score:** 5/5 truths verified (git artifacts)
+
+---
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+|----------|----------|--------|---------|
+| `infrastructure/controllers/base/cilium/release.yaml` | HelmRelease for Cilium 1.16.19 in kube-system | VERIFIED | Contains `chart: cilium`, `version: "1.16.19"`, `namespace: kube-system`, K3s-specific values (`k8sServiceHost: 127.0.0.1`, `k8sServicePort: 6444`), Hubble enabled with relay, UI, and Prometheus ServiceMonitor |
+| `infrastructure/controllers/base/cilium/repository.yaml` | HelmRepository pointing to helm.cilium.io | VERIFIED | `url: https://helm.cilium.io/` in `namespace: flux-system` |
+| `infrastructure/controllers/staging/cilium/ingress.yaml` | Traefik Ingress for Hubble UI at hubble.watarystack.org | VERIFIED | `host: hubble.watarystack.org`, `name: hubble-ui`, `port: 80`, `secretName: hubble-ui-tls`, `letsencrypt-cloudflare-prod` annotation present |
+| `apps/base/homepage/homepage-configmap.yaml` | Homepage entry for Hubble UI | VERIFIED | Contains `- Hubble:` block with `href: https://hubble.watarystack.org`, `description: Cilium network observability`, `icon: cilium.png` |
+
+---
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+|------|----|-----|--------|---------|
+| `infrastructure/controllers/base/cilium/release.yaml` | `kube-system/helmrelease/cilium` | FluxCD HelmRelease adoption | WIRED | `name: cilium`, `namespace: kube-system` matches the imperatively-installed helm release name; FluxCD will adopt on reconcile |
+| `infrastructure/controllers/staging/cilium/ingress.yaml` | `kube-system/service/hubble-ui:80` | Traefik Ingress | WIRED | `service.name: hubble-ui`, `port.number: 80` in kube-system namespace |
+| `infrastructure/controllers/base/cilium/kustomization.yaml` | base resources | Kustomize | WIRED | References `repository.yaml` and `release.yaml` |
+| `infrastructure/controllers/staging/cilium/kustomization.yaml` | staging resources | Kustomize | WIRED | References `../../base/cilium/` and `ingress.yaml` |
+| `infrastructure/controllers/base/kustomization.yaml` | `base/cilium/` | Kustomize resource entry | WIRED | `- cilium` present in resources list |
+| `infrastructure/controllers/staging/kustomization.yaml` | `staging/cilium/` | Kustomize resource entry | WIRED | `- cilium` present in resources list |
+
+---
+
+### Data-Flow Trace (Level 4)
+
+Not applicable. This phase produces Kubernetes declarative manifests (HelmRelease, HelmRepository, Ingress, ConfigMap) — not components that render dynamic data from a fetch/state source. The data-flow is: git commit -> FluxCD reconcile -> Kubernetes API apply. Runtime behavior requires human verification.
+
+---
+
+### Behavioral Spot-Checks
+
+Step 7b: SKIPPED — manifests require a live Kubernetes cluster and FluxCD to execute. No runnable entry points available for static spot-checks. Runtime behavior is covered in the Human Verification section.
+
+---
+
+### Requirements Coverage
+
+| Requirement | Source Plan | Description | Status | Evidence |
+|-------------|-------------|-------------|--------|---------|
+| SEC-01 | 09-03-PLAN.md | Cilium is installed as the CNI, replacing Flannel | SATISFIED (git) | HelmRelease committed in `base/cilium/release.yaml`; imperative install confirmed by 09-01 and 09-02 SUMMARYs |
+| SEC-02 | 09-03-PLAN.md | Hubble observability is enabled in Cilium | SATISFIED (git) | `release.yaml` values include `hubble.enabled: true`, `relay.enabled: true`, `ui.enabled: true`, Prometheus ServiceMonitor configured |
+
+**Traceability discrepancy noted:** REQUIREMENTS.md (line 105-106) maps SEC-01 and SEC-02 to Phase 10, but these requirements were delivered in Phase 9. The plan frontmatter (`09-03-PLAN.md`) and commit message (`37333ee`) explicitly claim SEC-01 and SEC-02. REQUIREMENTS.md traceability table should be updated to reflect Phase 9. This is a documentation inconsistency, not a gap in implementation.
+
+---
+
+### Anti-Patterns Found
+
+No anti-patterns found. Scanned:
+- `infrastructure/controllers/base/cilium/` — no TODO, FIXME, placeholder, empty returns
+- `infrastructure/controllers/staging/cilium/` — no TODO, FIXME, placeholder, empty returns
+- All YAML is substantive declarative configuration with real values
+
+---
+
+### Human Verification Required
+
+#### 1. FluxCD HelmRelease Adoption
+
+**Test:** After PR #54 merges to main, wait for FluxCD reconciliation (up to 1 minute), then run: `kubectl get helmrelease -n kube-system cilium`
+**Expected:** `READY=True`, `STATUS=Release reconciliation succeeded`, no pod restarts on cilium-agent or cilium-operator
+**Why human:** Cannot verify FluxCD adoption of an imperatively-installed Helm release without a live cluster. The risk is that FluxCD detects value drift between the committed HelmRelease and the bootstrapped install and triggers a re-install, which would cause a brief network outage.
+
+#### 2. Hubble UI Accessibility
+
+**Test:** After PR merges and FluxCD reconciles, run: `kubectl get ingress -n kube-system hubble-ui` and `kubectl get certificate -n kube-system hubble-ui-tls`, then browse to https://hubble.watarystack.org
+**Expected:** Ingress created, certificate in Ready state, Hubble UI loads showing network flows
+**Why human:** Requires running cluster, Traefik, cert-manager, and DNS routing. TLS issuance via Let's Encrypt DNS-01 challenge takes 1-2 minutes after reconciliation.
+
+#### 3. Network Connectivity Post-Migration
+
+**Test:** After merge, verify existing apps are still functional: `kubectl get pods --all-namespaces | grep -v Running` and check that all previously-working apps respond at their domains
+**Expected:** All pods remain Running; no CrashLoopBackOff; apps at their Cloudflare Tunnel URLs continue working
+**Why human:** Cilium migration (Plans 09-01/09-02) was imperative; this verification should have been done then, but the GitOps commit (PR #54) is the final gate before marking the phase complete.
+
+---
+
+### Gaps Summary
+
+No gaps in git artifacts. All five observable truths are verified against the actual codebase. The phase goal — bringing Cilium under GitOps control via FluxCD with Hubble UI exposed and on the homepage — is fully achieved at the git/manifest layer.
+
+Three items require human verification after PR #54 merges: FluxCD adoption confirmation, Hubble UI accessibility, and overall cluster health. These are expected post-merge runtime checks, not blockers to the phase's git deliverables.
+
+One administrative item: REQUIREMENTS.md traceability table should be updated to move SEC-01 and SEC-02 from Phase 10 to Phase 9.
+
+---
+
+_Verified: 2026-04-09T08:00:00Z_
+_Verifier: Claude (gsd-verifier)_

--- a/apps/base/homepage/homepage-configmap.yaml
+++ b/apps/base/homepage/homepage-configmap.yaml
@@ -54,6 +54,10 @@ data:
             href: https://longhorn.watarystack.org
             description: Distributed block storage
             icon: longhorn.png
+        - Hubble:
+            href: https://hubble.watarystack.org
+            description: Cilium network observability
+            icon: cilium.png
   widgets.yaml: |
     - kubernetes:
         cluster:

--- a/infrastructure/controllers/base/cilium/kustomization.yaml
+++ b/infrastructure/controllers/base/cilium/kustomization.yaml
@@ -1,8 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - renovate
-  - cert-manager
-  - cloudnative-pg
-  - longhorn
-  - cilium
+  - repository.yaml
+  - release.yaml

--- a/infrastructure/controllers/base/cilium/release.yaml
+++ b/infrastructure/controllers/base/cilium/release.yaml
@@ -1,0 +1,47 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cilium
+  namespace: kube-system
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: cilium
+      version: "1.16.19"
+      sourceRef:
+        kind: HelmRepository
+        name: cilium
+        namespace: flux-system
+      interval: 12h
+  install:
+    crds: Create
+  upgrade:
+    crds: CreateReplace
+  values:
+    k8sServiceHost: "127.0.0.1"
+    k8sServicePort: "6444"
+    ipam:
+      operator:
+        clusterPoolIPv4PodCIDRList:
+          - "10.42.0.0/16"
+    operator:
+      replicas: 1
+    hubble:
+      enabled: true
+      relay:
+        enabled: true
+      ui:
+        enabled: true
+      metrics:
+        enabled:
+          - dns:query;ignoreAAAA
+          - drop
+          - tcp
+          - flow
+          - icmp
+          - http
+        serviceMonitor:
+          enabled: true
+          labels:
+            release: kube-prometheus-stack

--- a/infrastructure/controllers/base/cilium/repository.yaml
+++ b/infrastructure/controllers/base/cilium/repository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: cilium
+  namespace: flux-system
+spec:
+  interval: 24h
+  url: https://helm.cilium.io/

--- a/infrastructure/controllers/base/kustomization.yaml
+++ b/infrastructure/controllers/base/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - renovate
   - cert-manager
   - cloudnative-pg
+  - cilium

--- a/infrastructure/controllers/staging/cilium/ingress.yaml
+++ b/infrastructure/controllers/staging/cilium/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: hubble-ui
+  namespace: kube-system
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-cloudflare-prod
+spec:
+  ingressClassName: traefik
+  tls:
+    - hosts:
+        - hubble.watarystack.org
+      secretName: hubble-ui-tls
+  rules:
+    - host: hubble.watarystack.org
+      http:
+        paths:
+          - backend:
+              service:
+                name: hubble-ui
+                port:
+                  number: 80
+            path: /
+            pathType: Prefix

--- a/infrastructure/controllers/staging/cilium/kustomization.yaml
+++ b/infrastructure/controllers/staging/cilium/kustomization.yaml
@@ -1,8 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - renovate
-  - cert-manager
-  - cloudnative-pg
-  - longhorn
-  - cilium
+  - ../../base/cilium/
+  - ingress.yaml


### PR DESCRIPTION
## Summary

Phase 9: Replaces Flannel with Cilium CNI (completed imperatively during maintenance window).

This PR adds the GitOps manifests for FluxCD to adopt and manage the Cilium install:

- **HelmRelease**: cilium/cilium 1.16.19 in kube-system — FluxCD will detect the existing helm release and adopt it
- **HelmRepository**: helm.cilium.io added to flux-system
- **Hubble UI Ingress**: Traefik Ingress at hubble.watarystack.org with cert-manager TLS
- **Homepage**: Hubble entry added to dashboard

### Cilium values (match bootstrap install from Plan 02)
- k8sServiceHost: 127.0.0.1, k8sServicePort: 6444 (K3s local API proxy)
- ipam.operator.clusterPoolIPv4PodCIDRList: 10.42.0.0/16
- operator.replicas: 1
- hubble.enabled + relay + ui + Prometheus ServiceMonitor

### Post-merge
FluxCD will reconcile and adopt the existing Cilium helm release. No pod restarts expected.

Closes SEC-01, SEC-02

🤖 Generated with [Claude Code](https://claude.com/claude-code)