### PR TITLE
feat: homepage redesign, Grafana dashboards, phase tracking updates

### DIFF
--- a/.claude/skills/homelab-app-onboarding/SKILL.md
+++ b/.claude/skills/homelab-app-onboarding/SKILL.md
@@ -263,10 +263,9 @@ spec:
   description: "PostgreSQL cluster for ${APP_NAME} application"
   instances: 1
 
-  # Enable monitoring (uncomment when Prometheus is configured)
-  # monitoring:
-  #   enabled: true
-  #   podMonitorEnabled: true
+  monitoring:
+    enabled: true
+    podMonitorEnabled: true
 
   postgresql:
     parameters:
@@ -966,9 +965,10 @@ Each app gets its own `cloudflared` deployment for:
 
 ---
 
-**Version**: 1.2
-**Last Updated**: April 7, 2026
+**Version**: 1.3
+**Last Updated**: April 11, 2026
 **Changelog:**
+- v1.3: Enabled CNPG monitoring by default (`monitoring.enabled: true`, `podMonitorEnabled: true`) — Prometheus is active and scrapes CNPG clusters — Phase 09
 - v1.2: Added CloudNativePG PostgreSQL support (Step 2.5) — full cluster + R2 backup matching linkding/n8n pattern
 - v1.2: Added DB env vars template to deployment.yaml (commented, for CloudNativePG connection)
 - v1.2: Skill now auto-detects whether to offer CloudNativePG based on app's PostgreSQL support

--- a/.claude/skills/new-worker-node/SKILL.md
+++ b/.claude/skills/new-worker-node/SKILL.md
@@ -70,6 +70,27 @@ kubectl get lhn -n longhorn-system   # Longhorn Node resources
 # If disk is <25% free, it shows Schedulable: false (expected for low-disk nodes)
 ```
 
+### Step 3.5 — Verify Cilium agent is running on new node (run on control-plane)
+
+The cluster uses Cilium as the CNI (replaced Flannel in Phase 9). Cilium deploys as a DaemonSet, so it automatically starts on the new node — but verify it reaches `Running` before declaring success. If the Cilium agent fails, pods on the new node will get no networking.
+
+```bash
+# Cilium agent should be Running on the new node within ~60 seconds
+kubectl get pods -n kube-system -l k8s-app=cilium -o wide
+# New node should appear with STATUS=Running
+
+# If still initializing, watch it:
+kubectl get pods -n kube-system -l k8s-app=cilium -o wide -w
+
+# If the agent is stuck, check its logs:
+kubectl logs -n kube-system -l k8s-app=cilium --tail=50
+
+# Quick connectivity check (requires cilium CLI):
+# cilium status --wait
+```
+
+> **Note:** Do NOT proceed to Step 4 (workload scheduling) until the Cilium agent on the new node is `Running`. Pods scheduled before Cilium is ready will fail with networking errors.
+
 ### Step 4 — Verify monitoring is active (run on control-plane)
 
 ```bash
@@ -111,6 +132,7 @@ node-label:
 | Task | Automatic? |
 |------|-----------|
 | K3s agent join | ❌ Manual (curl install command) |
+| **Cilium agent (CNI)** | ✅ DaemonSet deploys automatically — **verify Running before scheduling workloads** |
 | iscsi-installer (open-iscsi) | ✅ DaemonSet deploys automatically |
 | Longhorn storage detection | ✅ Automatic after iscsi is ready |
 | Prometheus node monitoring | ✅ DaemonSet deploys automatically |

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -8,14 +8,14 @@
 ### Critical Fixes (CRIT)
 
 - [x] **CRIT-01**: `apps` Kustomization has `dependsOn: [databases]` so apps never race databases on bootstrap
-- [ ] **CRIT-02**: audiobookshelf Deployment has resource `requests` and `limits` defined
+- [x] **CRIT-02**: audiobookshelf Deployment has resource `requests` and `limits` defined
 - [ ] **CRIT-03**: All deployments using `:latest` image tags are pinned to specific versions (n8n, cloudflared)
 - [x] **CRIT-04**: Grafana admin password is stored in a SOPS-encrypted Secret, not hardcoded in HelmRelease values
 - [ ] **CRIT-05**: Renovate external-host-error is diagnosed and resolved
 
 ### Backup (BACK)
 
-- [ ] **BACK-01**: n8n CloudNativePG cluster has a `ScheduledBackup` resource configured
+- [x] **BACK-01**: n8n CloudNativePG cluster has a `ScheduledBackup` resource configured
 - [x] **BACK-02**: linkding `ScheduledBackup` has a `destinationPath` pointing to object storage
 - [ ] **BACK-03**: Velero is installed and configured with an S3-compatible backup target
 - [ ] **BACK-04**: All app namespaces have Velero backup schedules (daily, configurable retention)
@@ -38,8 +38,8 @@
 
 ### Security (SEC)
 
-- [ ] **SEC-01**: Cilium is installed as the CNI, replacing Flannel
-- [ ] **SEC-02**: Hubble observability is enabled in Cilium
+- [x] **SEC-01**: Cilium is installed as the CNI, replacing Flannel
+- [x] **SEC-02**: Hubble observability is enabled in Cilium
 - [ ] **SEC-03**: A default-deny NetworkPolicy is applied in each app namespace
 - [ ] **SEC-04**: Allow-rules are configured per namespace so each app can reach only its own database and required services
 - [ ] **SEC-05**: flux-system existing NetworkPolicies are preserved and verified after Cilium migration
@@ -86,11 +86,11 @@
 | Requirement | Phase | Status |
 |-------------|-------|--------|
 | CRIT-01 | Phase 1 | Complete |
-| CRIT-02 | Phase 2 | Pending |
+| CRIT-02 | Phase 2 | Complete |
 | CRIT-03 | Unassigned | Pending |
 | CRIT-04 | Phase 3 | Complete |
 | CRIT-05 | Phase 4 | Pending |
-| BACK-01 | Phase 5 | Pending |
+| BACK-01 | Phase 5 | Complete |
 | BACK-02 | Phase 6 | Complete |
 | STOR-01 | Phase 7 | Complete |
 | STOR-02 | Phase 7 | Complete |
@@ -102,8 +102,8 @@
 | SCHED-01 | Phase 9 | Complete |
 | SCHED-02 | Phase 9 | Complete |
 | SCHED-03 | Phase 9 | Complete |
-| SEC-01 | Phase 10 | Pending |
-| SEC-02 | Phase 10 | Pending |
+| SEC-01 | Phase 10 | Complete |
+| SEC-02 | Phase 10 | Complete |
 | SEC-03 | Phase 11 | Pending |
 | SEC-04 | Phase 11 | Pending |
 | SEC-05 | Phase 11 | Pending |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -55,7 +55,7 @@ Plans:
 
 **Done when:** `grep -r "adminPassword" monitoring/` returns zero matches and Grafana login still works.
 
-**Plans:** 1 plan
+**Plans:** 1/1 plans complete
 
 Plans:
 - [x] 03-01-PLAN.md — Create SOPS-encrypted grafana-admin-secret and update HelmRelease to use existingSecret
@@ -108,13 +108,13 @@ Plans:
 
 **Requirements:** STOR-01, STOR-02, STOR-03, STOR-06, OBS-02
 
-**Plans:** 2/4 plans executed
+**Plans:** 4/4 plans complete
 
 Plans:
-- [ ] 06-01-PLAN.md — iscsi-installer DaemonSet prereq: namespace, DaemonSet, staging overlay wired into controller hierarchy
+- [x] 06-01-PLAN.md — iscsi-installer DaemonSet prereq: namespace, DaemonSet, staging overlay wired into controller hierarchy
 - [x] 06-02-PLAN.md — Longhorn HelmRelease: HelmRepository + HelmRelease with replica=2, default StorageClass, ServiceMonitor
 - [x] 06-03-PLAN.md — Longhorn UI ingress: Traefik Ingress at longhorn.watarystack.org pointing to longhorn-frontend:80
-- [ ] 06-04-PLAN.md — local-path demotion: K3s config disable local-storage on all nodes, K3s restart, StorageClass verification
+- [x] 06-04-PLAN.md — local-path demotion: K3s config disable local-storage on all nodes, K3s restart, StorageClass verification
 
 **Scope:**
 - Add `infrastructure/controllers/base/longhorn/` — HelmRelease, namespace, repository
@@ -183,12 +183,12 @@ Plans:
 
 **Requirements:** SEC-01, SEC-02
 
-**Plans:** 3 plans
+**Plans:** 3/3 plans complete
 
 Plans:
-- [ ] 09-01-PLAN.md — Maintenance window: disable Flannel in K3s config, restart all nodes, delete flannel.1 interface
-- [ ] 09-02-PLAN.md — Bootstrap Cilium 1.16.19 via helm, install cilium CLI, restart all pods to use Cilium networking
-- [ ] 09-03-PLAN.md — GitOps adoption: commit HelmRelease + Hubble UI Traefik Ingress + homepage entry, open PR
+- [x] 09-01-PLAN.md — Maintenance window: disable Flannel in K3s config, restart all nodes, delete flannel.1 interface
+- [x] 09-02-PLAN.md — Bootstrap Cilium 1.16.19 via helm, install cilium CLI, restart all pods to use Cilium networking
+- [x] 09-03-PLAN.md — GitOps adoption: commit HelmRelease + Hubble UI Traefik Ingress + homepage entry, open PR
 
 **Scope:**
 - Plan migration: disable k3s flannel, install Cilium via Helm in kube-system
@@ -260,15 +260,15 @@ Plans:
 
 | Phase | Name | Category | Risk | Est. Effort |
 |-------|------|----------|------|-------------|
-| 1 | Fix FluxCD Bootstrap Race | Critical Fix | Low | Small |
-| 2 | Resource Limits — audiobookshelf | Critical Fix | Low | Small |
-| 3 | Grafana Password to SOPS Secret | Security | Low | Small |
-| 4 | n8n Database Backup | Backup | Low | Small |
-| 5 | Fix linkding Backup Destination | 1/1 | Complete   | 2026-04-05 |
-| 6 | Install Longhorn Storage | 2/4 | In Progress|  |
-| 7 | Migrate PVCs to Longhorn | 7/7 | Complete   | 2026-04-06 |
-| 8 | Balance Workloads to Workers | 2/2 | Complete   | 2026-04-06 |
-| 9 | Cilium CNI Migration | Security | **High** | Large |
+| 1 | Fix FluxCD Bootstrap Race | Critical Fix | Complete    | 2026-04-10 |
+| 2 | Resource Limits — audiobookshelf | Critical Fix | Complete    | 2026-04-10 |
+| 3 | Grafana Password to SOPS Secret | Security | Complete    | 2026-04-10 |
+| 4 | n8n Database Backup | Backup | Complete    | 2026-04-10 |
+| 5 | Fix linkding Backup Destination | 1/1 | Complete    | 2026-04-10 |
+| 6 | Install Longhorn Storage | 2/4 | Complete    | 2026-04-10 |
+| 7 | Migrate PVCs to Longhorn | 7/7 | Complete    | 2026-04-10 |
+| 8 | Balance Workloads to Workers | 2/2 | Complete    | 2026-04-10 |
+| 9 | Cilium CNI Migration | Security | Complete    | 2026-04-10 |
 | 10 | NetworkPolicies per Namespace | Security | Medium | Medium |
 | 11 | Velero Full Backup | Backup | Low | Medium |
 | 12 | Headlamp Dashboard | Observability | Low | Small |

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -220,6 +220,13 @@ Plans:
   - flux-system existing policies preserved
 - Test isolation: verify mealie cannot reach linkding's postgres
 
+**Plans:** 3 plans
+
+Plans:
+- [ ] 10-01-PLAN.md — NetworkPolicies for linkding and n8n (default-deny + CNPG/Prometheus/pgadmin allow rules)
+- [ ] 10-02-PLAN.md — NetworkPolicies for mealie, audiobookshelf, pgadmin, filebrowser (default-deny + cloudflared allow)
+- [ ] 10-03-PLAN.md — NetworkPolicies for homepage and xm-spotify-sync (Traefik pattern) + full isolation checkpoint
+
 **Done when:** `kubectl get networkpolicies --all-namespaces` shows policies in all app namespaces, and cross-namespace DB access is blocked (verified by test pod).
 
 ---

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,7 +4,7 @@ milestone: v2.5.1
 milestone_name: milestone
 status: verifying
 stopped_at: Completed 08-02-PLAN.md (nodeAffinity for all 8 apps and Prometheus)
-last_updated: "2026-04-09T07:15:06.257Z"
+last_updated: "2026-04-10T20:30:26.289Z"
 progress:
   total_phases: 12
   completed_phases: 8

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,14 +2,14 @@
 gsd_state_version: 1.0
 milestone: v2.5.1
 milestone_name: milestone
-status: verifying
-stopped_at: Completed 08-02-PLAN.md (nodeAffinity for all 8 apps and Prometheus)
-last_updated: "2026-04-10T20:30:26.289Z"
+status: in_progress
+stopped_at: Completed Phase 09 — Cilium CNI Migration
+last_updated: "2026-04-11T00:00:00.000Z"
 progress:
   total_phases: 12
-  completed_phases: 8
-  total_plans: 20
-  completed_plans: 20
+  completed_phases: 9
+  total_plans: 23
+  completed_plans: 23
 ---
 
 # Project State
@@ -19,7 +19,7 @@ progress:
 See: .planning/PROJECT.md (updated 2026-04-04)
 
 **Core value:** Every stateful app survives any single node failure without data loss
-**Current focus:** Phase 09 — cilium-cni-migration
+**Current focus:** Phase 10 — NetworkPolicies per Namespace
 **Milestone:** v1 — Cluster Hardening & Resilience
 
 ## Current Phase
@@ -90,14 +90,14 @@ Next action: `/gsd:plan-phase 5`
 | Phase | Name | Status |
 |-------|------|--------|
 | 1 | Fix FluxCD Bootstrap Race | ✓ Complete |
-| 2 | Resource Limits — audiobookshelf | ○ Pending |
-| 3 | Grafana Password to SOPS Secret | ○ Pending |
+| 2 | Resource Limits — audiobookshelf | ✓ Complete |
+| 3 | Grafana Password to SOPS Secret | ✓ Complete |
 | 4 | n8n Database Backup | ✓ Complete |
-| 5 | Fix linkding Backup Destination | ○ Pending |
-| 6 | Install Longhorn Storage | ○ Pending |
-| 7 | Migrate PVCs to Longhorn | ✓ Complete (Plans 01-07 complete, PR #39 open) |
-| 8 | Balance Workloads to Workers | ○ Pending |
-| 9 | Cilium CNI Migration | ○ Pending |
+| 5 | Fix linkding Backup Destination | ✓ Complete |
+| 6 | Install Longhorn Storage | ✓ Complete |
+| 7 | Migrate PVCs to Longhorn | ✓ Complete |
+| 8 | Balance Workloads to Workers | ✓ Complete |
+| 9 | Cilium CNI Migration | ✓ Complete |
 | 10 | NetworkPolicies per Namespace | ○ Pending |
 | 11 | Velero Full Backup | ○ Pending |
 | 12 | Headlamp Dashboard | ○ Pending |

--- a/.planning/phases/10-networkpolicies-per-namespace-isolation/10-01-PLAN.md
+++ b/.planning/phases/10-networkpolicies-per-namespace-isolation/10-01-PLAN.md
@@ -1,0 +1,452 @@
+---
+phase: 10-networkpolicies-per-namespace-isolation
+plan: "01"
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - apps/base/linkding/network-policy.yaml
+  - apps/base/linkding/kustomization.yaml
+  - apps/base/n8n/network-policy.yaml
+  - apps/base/n8n/kustomization.yaml
+autonomous: true
+requirements:
+  - SEC-03
+  - SEC-04
+
+must_haves:
+  truths:
+    - "linkding namespace has a default-deny-ingress NetworkPolicy that blocks all unconfigured ingress"
+    - "n8n namespace has a default-deny-ingress NetworkPolicy that blocks all unconfigured ingress"
+    - "linkding app pod can reach its own postgres on port 5432"
+    - "n8n app pod can reach its own postgres on port 5432"
+    - "CNPG operator (cnpg-system) can reach linkding-postgres pods on ports 8000 and 5432"
+    - "CNPG operator (cnpg-system) can reach n8n-postgresql-cluster pods on ports 8000 and 5432"
+    - "Prometheus (monitoring namespace) can reach CNPG pods in both namespaces on port 9187"
+    - "pgadmin (pgadmin namespace) can reach both CNPG clusters on port 5432"
+    - "cloudflared pod can reach linkding app on port 9090"
+    - "cloudflared pod can reach n8n app on port 5678"
+  artifacts:
+    - path: "apps/base/linkding/network-policy.yaml"
+      provides: "All NetworkPolicies for the linkding namespace"
+      contains: "default-deny-ingress"
+    - path: "apps/base/n8n/network-policy.yaml"
+      provides: "All NetworkPolicies for the n8n namespace"
+      contains: "default-deny-ingress"
+    - path: "apps/base/linkding/kustomization.yaml"
+      provides: "Kustomization wiring network-policy.yaml into linkding base"
+      contains: "network-policy.yaml"
+    - path: "apps/base/n8n/kustomization.yaml"
+      provides: "Kustomization wiring network-policy.yaml into n8n base"
+      contains: "network-policy.yaml"
+  key_links:
+    - from: "apps/base/linkding/kustomization.yaml"
+      to: "apps/base/linkding/network-policy.yaml"
+      via: "resources entry"
+      pattern: "network-policy\\.yaml"
+    - from: "apps/base/n8n/kustomization.yaml"
+      to: "apps/base/n8n/network-policy.yaml"
+      via: "resources entry"
+      pattern: "network-policy\\.yaml"
+---
+
+<objective>
+Add NetworkPolicies to the linkding and n8n namespaces — the two most complex app namespaces because each hosts both an app pod and a CloudNativePG postgres cluster.
+
+Purpose: Enforce per-namespace ingress isolation (SEC-03) with explicit allow-rules for every legitimate traffic flow (SEC-04): cloudflared tunnel, app-to-postgres, CNPG operator health checks (port 8000 + 5432), Prometheus metrics scraping (port 9187), and pgadmin cross-namespace DB admin access.
+
+Output: `apps/base/linkding/network-policy.yaml` and `apps/base/n8n/network-policy.yaml`, each containing 5 NetworkPolicy objects, wired into each base kustomization.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/10-networkpolicies-per-namespace-isolation/10-RESEARCH.md
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Create linkding NetworkPolicies (default-deny + 5 allow rules)</name>
+  <files>apps/base/linkding/network-policy.yaml, apps/base/linkding/kustomization.yaml</files>
+
+  <read_first>
+    - apps/base/linkding/kustomization.yaml (add network-policy.yaml to resources)
+    - apps/base/linkding/deployment.yaml (confirm app pod labels — verify `app: linkding`)
+    - apps/base/linkding/service.yaml (confirm port 9090)
+  </read_first>
+
+  <action>
+Create `apps/base/linkding/network-policy.yaml` with exactly these 6 NetworkPolicy objects (separated by `---`):
+
+**Object 1 — default-deny-ingress:**
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+```
+
+**Object 2 — allow-cloudflared** (cloudflared pod → linkding app on port 9090):
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-cloudflared
+spec:
+  podSelector:
+    matchLabels:
+      app: linkding
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: cloudflared
+    ports:
+    - port: 9090
+      protocol: TCP
+```
+
+**Object 3 — allow-app-to-postgres** (linkding app pod → CNPG postgres pods on port 5432):
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-app-to-postgres
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: linkding-postgres
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: linkding
+    ports:
+    - port: 5432
+      protocol: TCP
+```
+
+**Object 4 — allow-cnpg-operator** (CNPG operator from cnpg-system → CNPG pods on ports 8000 AND 5432):
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-cnpg-operator
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: linkding-postgres
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: cnpg-system
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: cloudnative-pg
+    ports:
+    - port: 8000
+      protocol: TCP
+    - port: 5432
+      protocol: TCP
+```
+
+CRITICAL: `namespaceSelector` and `podSelector` must be in the SAME list entry (AND logic). Separate list entries = OR logic = security hole.
+
+**Object 5 — allow-prometheus-scrape** (Prometheus from monitoring namespace → CNPG pods on port 9187):
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-prometheus-scrape
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: linkding-postgres
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: monitoring
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: prometheus
+    ports:
+    - port: 9187
+      protocol: TCP
+```
+
+**Object 6 — allow-pgadmin** (pgadmin namespace → CNPG pods on port 5432, namespace-only selector — pgadmin has one pod):
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-pgadmin
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: linkding-postgres
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: pgadmin
+    ports:
+    - port: 5432
+      protocol: TCP
+```
+
+Then update `apps/base/linkding/kustomization.yaml` to add `- network-policy.yaml` to the `resources:` list (after `service.yaml`).
+
+Validate: `kustomize build apps/base/linkding/ --dry-run 2>&1 | head -20` — should output no errors and list all 6 NetworkPolicy names.
+  </action>
+
+  <verify>
+    <automated>grep -c "kind: NetworkPolicy" /home/santi/projects/HomeLab-Pro/apps/base/linkding/network-policy.yaml</automated>
+    <automated>grep "network-policy.yaml" /home/santi/projects/HomeLab-Pro/apps/base/linkding/kustomization.yaml</automated>
+    <automated>grep "default-deny-ingress" /home/santi/projects/HomeLab-Pro/apps/base/linkding/network-policy.yaml</automated>
+    <automated>grep "allow-cnpg-operator" /home/santi/projects/HomeLab-Pro/apps/base/linkding/network-policy.yaml</automated>
+    <automated>grep "port: 8000" /home/santi/projects/HomeLab-Pro/apps/base/linkding/network-policy.yaml</automated>
+    <automated>grep "port: 9187" /home/santi/projects/HomeLab-Pro/apps/base/linkding/network-policy.yaml</automated>
+    <automated>grep "allow-pgadmin" /home/santi/projects/HomeLab-Pro/apps/base/linkding/network-policy.yaml</automated>
+  </verify>
+
+  <acceptance_criteria>
+    - `grep -c "kind: NetworkPolicy" apps/base/linkding/network-policy.yaml` returns `6`
+    - `grep "network-policy.yaml" apps/base/linkding/kustomization.yaml` exits 0
+    - File contains `name: default-deny-ingress` with `podSelector: {}` and `policyTypes: [Ingress]`
+    - File contains `port: 8000` (CNPG operator health check — easy to forget)
+    - File contains `port: 9187` (Prometheus CNPG metrics — easy to forget)
+    - File contains `allow-pgadmin` rule with `kubernetes.io/metadata.name: pgadmin`
+    - YAML uses AND semantics: `namespaceSelector` and `podSelector` are sibling keys in the same `from` list entry (NOT separate list items)
+    - `kustomize build apps/base/linkding/` exits 0 (no YAML parse errors)
+  </acceptance_criteria>
+
+  <done>linkding/network-policy.yaml has 6 NetworkPolicy objects and is wired into the base kustomization. kustomize build exits 0.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Create n8n NetworkPolicies (default-deny + 5 allow rules)</name>
+  <files>apps/base/n8n/network-policy.yaml, apps/base/n8n/kustomization.yaml</files>
+
+  <read_first>
+    - apps/base/n8n/kustomization.yaml (add network-policy.yaml to resources)
+    - apps/base/n8n/deployment.yaml (confirm app pod labels — verify `app: n8n`)
+    - apps/base/n8n/service.yaml (confirm port 5678)
+  </read_first>
+
+  <action>
+Create `apps/base/n8n/network-policy.yaml` with exactly these 6 NetworkPolicy objects (separated by `---`). This mirrors the linkding structure but with `app: n8n`, port `5678`, and `cnpg.io/cluster: n8n-postgresql-cluster`:
+
+**Object 1 — default-deny-ingress:**
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+```
+
+**Object 2 — allow-cloudflared** (cloudflared → n8n on port 5678):
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-cloudflared
+spec:
+  podSelector:
+    matchLabels:
+      app: n8n
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: cloudflared
+    ports:
+    - port: 5678
+      protocol: TCP
+```
+
+**Object 3 — allow-app-to-postgres** (n8n app → CNPG postgres on port 5432):
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-app-to-postgres
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: n8n-postgresql-cluster
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: n8n
+    ports:
+    - port: 5432
+      protocol: TCP
+```
+
+**Object 4 — allow-cnpg-operator** (CNPG operator from cnpg-system → CNPG pods on ports 8000 AND 5432):
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-cnpg-operator
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: n8n-postgresql-cluster
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: cnpg-system
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: cloudnative-pg
+    ports:
+    - port: 8000
+      protocol: TCP
+    - port: 5432
+      protocol: TCP
+```
+
+**Object 5 — allow-prometheus-scrape** (Prometheus from monitoring → CNPG pods on port 9187):
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-prometheus-scrape
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: n8n-postgresql-cluster
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: monitoring
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: prometheus
+    ports:
+    - port: 9187
+      protocol: TCP
+```
+
+**Object 6 — allow-pgadmin** (pgadmin namespace → CNPG pods on port 5432):
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-pgadmin
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: n8n-postgresql-cluster
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: pgadmin
+    ports:
+    - port: 5432
+      protocol: TCP
+```
+
+Then update `apps/base/n8n/kustomization.yaml` to add `- network-policy.yaml` to the `resources:` list.
+
+Validate: `kustomize build apps/base/n8n/` exits 0.
+  </action>
+
+  <verify>
+    <automated>grep -c "kind: NetworkPolicy" /home/santi/projects/HomeLab-Pro/apps/base/n8n/network-policy.yaml</automated>
+    <automated>grep "network-policy.yaml" /home/santi/projects/HomeLab-Pro/apps/base/n8n/kustomization.yaml</automated>
+    <automated>grep "n8n-postgresql-cluster" /home/santi/projects/HomeLab-Pro/apps/base/n8n/network-policy.yaml</automated>
+    <automated>grep "port: 8000" /home/santi/projects/HomeLab-Pro/apps/base/n8n/network-policy.yaml</automated>
+    <automated>grep "port: 9187" /home/santi/projects/HomeLab-Pro/apps/base/n8n/network-policy.yaml</automated>
+    <automated>grep "port: 5678" /home/santi/projects/HomeLab-Pro/apps/base/n8n/network-policy.yaml</automated>
+  </verify>
+
+  <acceptance_criteria>
+    - `grep -c "kind: NetworkPolicy" apps/base/n8n/network-policy.yaml` returns `6`
+    - `grep "network-policy.yaml" apps/base/n8n/kustomization.yaml` exits 0
+    - File contains `cnpg.io/cluster: n8n-postgresql-cluster` (NOT `linkding-postgres` — easy copy-paste error)
+    - File contains `port: 8000` for CNPG operator
+    - File contains `port: 9187` for Prometheus scrape
+    - File contains `port: 5678` for cloudflared → n8n
+    - `kustomize build apps/base/n8n/` exits 0
+  </acceptance_criteria>
+
+  <done>n8n/network-policy.yaml has 6 NetworkPolicy objects and is wired into the base kustomization. kustomize build exits 0.</done>
+</task>
+
+</tasks>
+
+<verification>
+After both tasks complete, run dry-run against staging overlays:
+
+```bash
+kustomize build apps/staging/linkding/ 2>&1 | grep -E "error|Error" || echo "linkding: OK"
+kustomize build apps/staging/n8n/ 2>&1 | grep -E "error|Error" || echo "n8n: OK"
+```
+
+Verify policy count per namespace:
+```bash
+grep -c "kind: NetworkPolicy" apps/base/linkding/network-policy.yaml  # expect: 6
+grep -c "kind: NetworkPolicy" apps/base/n8n/network-policy.yaml       # expect: 6
+```
+
+Verify CNPG port 8000 is present in both files (the most common pitfall):
+```bash
+grep -l "port: 8000" apps/base/linkding/network-policy.yaml apps/base/n8n/network-policy.yaml | wc -l  # expect: 2
+```
+</verification>
+
+<success_criteria>
+- apps/base/linkding/network-policy.yaml and apps/base/n8n/network-policy.yaml both exist
+- Each file contains exactly 6 NetworkPolicy objects (grep -c "kind: NetworkPolicy" == 6)
+- Both files are referenced in their respective kustomization.yaml resources lists
+- Both files contain port 8000 (CNPG operator) and port 9187 (Prometheus scrape)
+- AND semantics used for cross-namespace rules (namespaceSelector + podSelector are siblings in same `from` list entry)
+- kustomize build of both base directories exits 0
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/10-networkpolicies-per-namespace-isolation/10-01-SUMMARY.md`
+</output>

--- a/.planning/phases/10-networkpolicies-per-namespace-isolation/10-02-PLAN.md
+++ b/.planning/phases/10-networkpolicies-per-namespace-isolation/10-02-PLAN.md
@@ -1,0 +1,248 @@
+---
+phase: 10-networkpolicies-per-namespace-isolation
+plan: "02"
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - apps/base/mealie/network-policy.yaml
+  - apps/base/mealie/kustomization.yaml
+  - apps/base/audiobookshelf/network-policy.yaml
+  - apps/base/audiobookshelf/kustomization.yaml
+  - apps/base/pgadmin/network-policy.yaml
+  - apps/base/pgadmin/kustomization.yaml
+  - apps/base/filebrowser/network-policy.yaml
+  - apps/base/filebrowser/kustomization.yaml
+autonomous: true
+requirements:
+  - SEC-03
+  - SEC-04
+must_haves:
+  truths:
+    - "mealie namespace blocks all ingress by default, only cloudflared can reach it on port 9000"
+    - "audiobookshelf namespace blocks all ingress by default, only cloudflared can reach it on port 3005"
+    - "pgadmin namespace blocks all ingress by default, only cloudflared can reach it on port 80"
+    - "filebrowser namespace blocks all ingress by default, only cloudflared can reach it on port 8088"
+  artifacts:
+    - path: "apps/base/mealie/network-policy.yaml"
+      provides: "NetworkPolicies for mealie namespace"
+      contains: "default-deny-ingress"
+    - path: "apps/base/audiobookshelf/network-policy.yaml"
+      provides: "NetworkPolicies for audiobookshelf namespace"
+      contains: "default-deny-ingress"
+    - path: "apps/base/pgadmin/network-policy.yaml"
+      provides: "NetworkPolicies for pgadmin namespace"
+      contains: "default-deny-ingress"
+    - path: "apps/base/filebrowser/network-policy.yaml"
+      provides: "NetworkPolicies for filebrowser namespace"
+      contains: "default-deny-ingress"
+  key_links:
+    - from: "apps/base/mealie/kustomization.yaml"
+      to: "apps/base/mealie/network-policy.yaml"
+      via: "resources entry"
+    - from: "apps/base/audiobookshelf/kustomization.yaml"
+      to: "apps/base/audiobookshelf/network-policy.yaml"
+      via: "resources entry"
+    - from: "apps/base/pgadmin/kustomization.yaml"
+      to: "apps/base/pgadmin/network-policy.yaml"
+      via: "resources entry"
+    - from: "apps/base/filebrowser/kustomization.yaml"
+      to: "apps/base/filebrowser/network-policy.yaml"
+      via: "resources entry"
+---
+
+<objective>
+Add NetworkPolicies to the 4 simple Cloudflare Tunnel app namespaces: mealie, audiobookshelf, pgadmin, and filebrowser. These namespaces each have exactly 2 policies: default-deny-ingress and allow-cloudflared (same-namespace only).
+
+Purpose: Apply SEC-03 default-deny and SEC-04 allow-cloudflared to the remaining Cloudflare Tunnel namespaces. Unlike linkding/n8n, these namespaces have no CNPG cluster and need only one allow rule each.
+
+Output: 4 `network-policy.yaml` files with 2 NetworkPolicy objects each, wired into their respective base kustomizations.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/10-networkpolicies-per-namespace-isolation/10-RESEARCH.md
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Create mealie and audiobookshelf NetworkPolicies</name>
+  <files>apps/base/mealie/network-policy.yaml, apps/base/mealie/kustomization.yaml, apps/base/audiobookshelf/network-policy.yaml, apps/base/audiobookshelf/kustomization.yaml</files>
+
+  <read_first>
+    - apps/base/mealie/kustomization.yaml (add network-policy.yaml to resources)
+    - apps/base/mealie/service.yaml (confirm port 9000)
+    - apps/base/mealie/deployment.yaml (confirm app pod label — verify `app: mealie`)
+    - apps/base/audiobookshelf/kustomization.yaml (add network-policy.yaml to resources)
+    - apps/base/audiobookshelf/service.yaml (confirm port 3005)
+    - apps/base/audiobookshelf/deployment.yaml (confirm app pod label — verify `app: audiobookshelf`)
+  </read_first>
+
+  <action>
+Create `apps/base/mealie/network-policy.yaml`. The file must contain 2 YAML documents separated by `---`. Document 1: default-deny-ingress. Document 2: allow-cloudflared.
+
+Document 1 (default-deny-ingress):
+- apiVersion: networking.k8s.io/v1
+- kind: NetworkPolicy
+- metadata.name: default-deny-ingress
+- spec.podSelector: {} (empty — matches all pods)
+- spec.policyTypes: [Ingress]
+- spec.ingress: (omit entirely — no ingress rules = deny all)
+
+Document 2 (allow-cloudflared for mealie):
+- apiVersion: networking.k8s.io/v1
+- kind: NetworkPolicy
+- metadata.name: allow-cloudflared
+- spec.podSelector.matchLabels: {app: mealie} (target: the mealie app pod)
+- spec.policyTypes: [Ingress]
+- spec.ingress[0].from[0].podSelector.matchLabels: {app: cloudflared} (source: cloudflared in same namespace)
+- spec.ingress[0].ports[0]: {port: 9000, protocol: TCP}
+
+Then add `- network-policy.yaml` to the `resources:` list in `apps/base/mealie/kustomization.yaml`.
+
+Create `apps/base/audiobookshelf/network-policy.yaml` with the same 2-document structure:
+
+Document 1: identical default-deny-ingress (same as above).
+
+Document 2 (allow-cloudflared for audiobookshelf):
+- metadata.name: allow-cloudflared
+- spec.podSelector.matchLabels: {app: audiobookshelf}
+- spec.ingress[0].from[0].podSelector.matchLabels: {app: cloudflared}
+- spec.ingress[0].ports[0]: {port: 3005, protocol: TCP}
+
+Then add `- network-policy.yaml` to `resources:` in `apps/base/audiobookshelf/kustomization.yaml`.
+
+Validate: `kustomize build apps/base/mealie/` and `kustomize build apps/base/audiobookshelf/` must exit 0.
+
+NOTE: Confirm app pod labels match deployment.yaml selector before writing the allow rule target.
+  </action>
+
+  <verify>
+    <automated>grep -c "kind: NetworkPolicy" /home/santi/projects/HomeLab-Pro/apps/base/mealie/network-policy.yaml</automated>
+    <automated>grep -c "kind: NetworkPolicy" /home/santi/projects/HomeLab-Pro/apps/base/audiobookshelf/network-policy.yaml</automated>
+    <automated>grep "network-policy.yaml" /home/santi/projects/HomeLab-Pro/apps/base/mealie/kustomization.yaml</automated>
+    <automated>grep "network-policy.yaml" /home/santi/projects/HomeLab-Pro/apps/base/audiobookshelf/kustomization.yaml</automated>
+    <automated>grep "port: 9000" /home/santi/projects/HomeLab-Pro/apps/base/mealie/network-policy.yaml</automated>
+    <automated>grep "port: 3005" /home/santi/projects/HomeLab-Pro/apps/base/audiobookshelf/network-policy.yaml</automated>
+  </verify>
+
+  <acceptance_criteria>
+    - `grep -c "kind: NetworkPolicy" apps/base/mealie/network-policy.yaml` returns `2`
+    - `grep -c "kind: NetworkPolicy" apps/base/audiobookshelf/network-policy.yaml` returns `2`
+    - `grep "network-policy.yaml" apps/base/mealie/kustomization.yaml` exits 0
+    - `grep "network-policy.yaml" apps/base/audiobookshelf/kustomization.yaml` exits 0
+    - mealie file contains `port: 9000` and `app: mealie` in allow-cloudflared target selector
+    - audiobookshelf file contains `port: 3005` and `app: audiobookshelf` in allow-cloudflared target selector
+    - Both files contain `podSelector: {}` under `default-deny-ingress` (empty selector = all pods)
+    - `kustomize build apps/base/mealie/` exits 0
+    - `kustomize build apps/base/audiobookshelf/` exits 0
+  </acceptance_criteria>
+
+  <done>mealie and audiobookshelf network-policy.yaml files created with 2 policies each, wired into base kustomizations, kustomize build passes.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Create pgadmin and filebrowser NetworkPolicies</name>
+  <files>apps/base/pgadmin/network-policy.yaml, apps/base/pgadmin/kustomization.yaml, apps/base/filebrowser/network-policy.yaml, apps/base/filebrowser/kustomization.yaml</files>
+
+  <read_first>
+    - apps/base/pgadmin/kustomization.yaml (add network-policy.yaml to resources)
+    - apps/base/pgadmin/service.yaml (confirm port 80)
+    - apps/base/pgadmin/deployment.yaml (confirm app pod label — verify `app: pgadmin`)
+    - apps/base/filebrowser/kustomization.yaml (add network-policy.yaml to resources)
+    - apps/base/filebrowser/service.yaml (confirm port 8088)
+    - apps/base/filebrowser/deployment.yaml (confirm app pod label — verify `app: filebrowser`)
+  </read_first>
+
+  <action>
+Create `apps/base/pgadmin/network-policy.yaml` with 2 YAML documents separated by `---`:
+
+Document 1: identical default-deny-ingress (podSelector: {}, policyTypes: [Ingress], no ingress rules).
+
+Document 2 (allow-cloudflared for pgadmin):
+- metadata.name: allow-cloudflared
+- spec.podSelector.matchLabels: {app: pgadmin}
+- spec.ingress[0].from[0].podSelector.matchLabels: {app: cloudflared}
+- spec.ingress[0].ports[0]: {port: 80, protocol: TCP}
+
+Then add `- network-policy.yaml` to `resources:` in `apps/base/pgadmin/kustomization.yaml`.
+
+Create `apps/base/filebrowser/network-policy.yaml` with 2 YAML documents:
+
+Document 1: identical default-deny-ingress.
+
+Document 2 (allow-cloudflared for filebrowser):
+- metadata.name: allow-cloudflared
+- spec.podSelector.matchLabels: {app: filebrowser}
+- spec.ingress[0].from[0].podSelector.matchLabels: {app: cloudflared}
+- spec.ingress[0].ports[0]: {port: 8088, protocol: TCP}
+
+Then add `- network-policy.yaml` to `resources:` in `apps/base/filebrowser/kustomization.yaml`.
+
+IMPORTANT on pgadmin: The default-deny-ingress blocks pgadmin UI from anyone except cloudflared. pgadmin's OUTBOUND connections to linkding-postgres and n8n-postgresql-cluster are egress (not affected by ingress deny). The allow-pgadmin rules in the linkding and n8n namespaces (Plan 01) permit those incoming connections on the postgres side. So pgadmin itself only needs: default-deny-ingress + allow-cloudflared.
+
+Validate: `kustomize build apps/base/pgadmin/` and `kustomize build apps/base/filebrowser/` must exit 0.
+  </action>
+
+  <verify>
+    <automated>grep -c "kind: NetworkPolicy" /home/santi/projects/HomeLab-Pro/apps/base/pgadmin/network-policy.yaml</automated>
+    <automated>grep -c "kind: NetworkPolicy" /home/santi/projects/HomeLab-Pro/apps/base/filebrowser/network-policy.yaml</automated>
+    <automated>grep "network-policy.yaml" /home/santi/projects/HomeLab-Pro/apps/base/pgadmin/kustomization.yaml</automated>
+    <automated>grep "network-policy.yaml" /home/santi/projects/HomeLab-Pro/apps/base/filebrowser/kustomization.yaml</automated>
+    <automated>grep "port: 80" /home/santi/projects/HomeLab-Pro/apps/base/pgadmin/network-policy.yaml</automated>
+    <automated>grep "port: 8088" /home/santi/projects/HomeLab-Pro/apps/base/filebrowser/network-policy.yaml</automated>
+  </verify>
+
+  <acceptance_criteria>
+    - `grep -c "kind: NetworkPolicy" apps/base/pgadmin/network-policy.yaml` returns `2`
+    - `grep -c "kind: NetworkPolicy" apps/base/filebrowser/network-policy.yaml` returns `2`
+    - `grep "network-policy.yaml" apps/base/pgadmin/kustomization.yaml` exits 0
+    - `grep "network-policy.yaml" apps/base/filebrowser/kustomization.yaml` exits 0
+    - pgadmin file contains `port: 80` in allow-cloudflared
+    - filebrowser file contains `port: 8088` in allow-cloudflared
+    - Both files contain `default-deny-ingress` policy with `podSelector: {}`
+    - `kustomize build apps/base/pgadmin/` exits 0
+    - `kustomize build apps/base/filebrowser/` exits 0
+  </acceptance_criteria>
+
+  <done>pgadmin and filebrowser network-policy.yaml files created with 2 policies each, wired into base kustomizations, kustomize build passes.</done>
+</task>
+
+</tasks>
+
+<verification>
+After both tasks complete, verify all 4 new files exist and kustomize builds pass:
+
+```bash
+for app in mealie audiobookshelf pgadmin filebrowser; do
+  count=$(grep -c "kind: NetworkPolicy" apps/base/$app/network-policy.yaml 2>/dev/null || echo "MISSING")
+  echo "$app: $count policies"
+done
+# Expected: each shows "2"
+
+for app in mealie audiobookshelf pgadmin filebrowser; do
+  kustomize build apps/base/$app/ > /dev/null 2>&1 && echo "$app: OK" || echo "$app: FAIL"
+done
+# Expected: all 4 show OK
+```
+</verification>
+
+<success_criteria>
+- 4 new network-policy.yaml files created (mealie, audiobookshelf, pgadmin, filebrowser)
+- Each file contains exactly 2 NetworkPolicy objects: default-deny-ingress + allow-cloudflared
+- All 4 files referenced in their respective base kustomization.yaml resources lists
+- Correct app port per namespace: mealie=9000, audiobookshelf=3005, pgadmin=80, filebrowser=8088
+- kustomize build passes for all 4 base directories
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/10-networkpolicies-per-namespace-isolation/10-02-SUMMARY.md`
+</output>

--- a/.planning/phases/10-networkpolicies-per-namespace-isolation/10-03-PLAN.md
+++ b/.planning/phases/10-networkpolicies-per-namespace-isolation/10-03-PLAN.md
@@ -2,8 +2,8 @@
 phase: 10-networkpolicies-per-namespace-isolation
 plan: "03"
 type: execute
-wave: 1
-depends_on: []
+wave: 2
+depends_on: ["01", "02"]
 files_modified:
   - apps/base/homepage/network-policy.yaml
   - apps/base/homepage/kustomization.yaml

--- a/.planning/phases/10-networkpolicies-per-namespace-isolation/10-03-PLAN.md
+++ b/.planning/phases/10-networkpolicies-per-namespace-isolation/10-03-PLAN.md
@@ -1,0 +1,233 @@
+---
+phase: 10-networkpolicies-per-namespace-isolation
+plan: "03"
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - apps/base/homepage/network-policy.yaml
+  - apps/base/homepage/kustomization.yaml
+  - apps/base/xm-spotify-sync/network-policy.yaml
+  - apps/base/xm-spotify-sync/kustomization.yaml
+autonomous: false
+requirements:
+  - SEC-03
+  - SEC-04
+  - SEC-05
+must_haves:
+  truths:
+    - "homepage namespace blocks all ingress by default, only Traefik (kube-system) can reach it on port 3000"
+    - "xm-spotify-sync namespace blocks all ingress by default, only Traefik (kube-system) can reach it on ports 22111 and 22112"
+    - "flux-system still has exactly 3 NetworkPolicies: allow-egress, allow-scraping, allow-webhooks"
+    - "All app pods across all 8 namespaces are Running after all policies are applied"
+    - "mealie cannot reach linkding's postgres (cross-namespace isolation verified)"
+  artifacts:
+    - path: "apps/base/homepage/network-policy.yaml"
+      provides: "NetworkPolicies for homepage namespace"
+      contains: "allow-traefik"
+    - path: "apps/base/xm-spotify-sync/network-policy.yaml"
+      provides: "NetworkPolicies for xm-spotify-sync namespace"
+      contains: "allow-traefik"
+  key_links:
+    - from: "apps/base/homepage/kustomization.yaml"
+      to: "apps/base/homepage/network-policy.yaml"
+      via: "resources entry"
+    - from: "apps/base/xm-spotify-sync/kustomization.yaml"
+      to: "apps/base/xm-spotify-sync/network-policy.yaml"
+      via: "resources entry"
+---
+
+<objective>
+Add NetworkPolicies to homepage and xm-spotify-sync (the two Traefik Ingress namespaces, not Cloudflare Tunnel), then run the full phase verification including SEC-05 flux-system policy preservation check and cross-namespace isolation test.
+
+Purpose: Complete the 8-namespace coverage with the Traefik pattern (kube-system namespaceSelector + traefik podSelector instead of same-namespace cloudflared podSelector). Traefik routes from kube-system, so allow rules must permit cross-namespace ingress from Traefik — a different pattern from the cloudflared namespaces. The checkpoint verifies the critical isolation property (mealie cannot reach linkding postgres) and that flux-system policies are untouched (SEC-05).
+
+Output: 2 network-policy.yaml files (homepage: 2 policies, xm-spotify-sync: 2 policies), plus human verification of isolation and flux-system integrity.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/10-networkpolicies-per-namespace-isolation/10-RESEARCH.md
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Create homepage and xm-spotify-sync NetworkPolicies (Traefik pattern)</name>
+  <files>apps/base/homepage/network-policy.yaml, apps/base/homepage/kustomization.yaml, apps/base/xm-spotify-sync/network-policy.yaml, apps/base/xm-spotify-sync/kustomization.yaml</files>
+
+  <read_first>
+    - apps/base/homepage/kustomization.yaml (add network-policy.yaml to resources list)
+    - apps/base/homepage/deployment.yaml (confirm pod label — verify `app.kubernetes.io/name: homepage`)
+    - apps/base/homepage/service.yaml (confirm port 3000)
+    - apps/base/xm-spotify-sync/kustomization.yaml (add network-policy.yaml to resources list)
+    - apps/base/xm-spotify-sync/deployment.yaml (confirm pod label — verify `app: xm-spotify-sync`)
+    - apps/base/xm-spotify-sync/service.yaml (confirm ports 22111 and 22112)
+  </read_first>
+
+  <action>
+Create `apps/base/homepage/network-policy.yaml` with 2 YAML documents separated by `---`.
+
+NOTE: homepage uses Traefik Ingress (kube-system namespace), NOT Cloudflare Tunnel. The allow rule must use a cross-namespace AND selector — both namespaceSelector and podSelector in the SAME `from` list entry.
+
+Document 1 (default-deny-ingress):
+- apiVersion: networking.k8s.io/v1
+- kind: NetworkPolicy
+- metadata.name: default-deny-ingress
+- spec.podSelector: {} (empty — matches all pods)
+- spec.policyTypes: [Ingress]
+- (no ingress field — deny all)
+
+Document 2 (allow-traefik for homepage):
+- apiVersion: networking.k8s.io/v1
+- kind: NetworkPolicy
+- metadata.name: allow-traefik
+- spec.podSelector.matchLabels: {app.kubernetes.io/name: homepage} (target: homepage pod)
+- spec.policyTypes: [Ingress]
+- spec.ingress[0].from[0]: COMBINED entry with BOTH selectors as siblings:
+  - namespaceSelector.matchLabels: {kubernetes.io/metadata.name: kube-system}
+  - podSelector.matchLabels: {app.kubernetes.io/name: traefik}
+  (CRITICAL: these are siblings in the same list item — AND semantics, not separate list items which would be OR)
+- spec.ingress[0].ports[0]: {port: 3000, protocol: TCP}
+
+Then add `- network-policy.yaml` to `resources:` in `apps/base/homepage/kustomization.yaml`.
+
+Create `apps/base/xm-spotify-sync/network-policy.yaml` with 2 YAML documents.
+
+NOTE: xm-spotify-sync has TWO ports (22111 frontend, 22112 backend API). Both must be allowed.
+
+Document 1: identical default-deny-ingress.
+
+Document 2 (allow-traefik for xm-spotify-sync):
+- metadata.name: allow-traefik
+- spec.podSelector.matchLabels: {app: xm-spotify-sync}
+- spec.ingress[0].from[0]: COMBINED entry:
+  - namespaceSelector.matchLabels: {kubernetes.io/metadata.name: kube-system}
+  - podSelector.matchLabels: {app.kubernetes.io/name: traefik}
+- spec.ingress[0].ports:
+  - {port: 22111, protocol: TCP}
+  - {port: 22112, protocol: TCP}
+
+Then add `- network-policy.yaml` to `resources:` in `apps/base/xm-spotify-sync/kustomization.yaml`.
+
+AND vs OR reminder: In the `from` list, each item is either a single selector (podSelector OR namespaceSelector) or an object with BOTH selectors (AND). If you put them as separate list items, it means "from any pod in kube-system namespace OR from any pod with traefik label cluster-wide" — a security hole. Use one object with both selectors.
+
+Validate both: `kustomize build apps/base/homepage/` and `kustomize build apps/base/xm-spotify-sync/` must exit 0.
+  </action>
+
+  <verify>
+    <automated>grep -c "kind: NetworkPolicy" /home/santi/projects/HomeLab-Pro/apps/base/homepage/network-policy.yaml</automated>
+    <automated>grep -c "kind: NetworkPolicy" /home/santi/projects/HomeLab-Pro/apps/base/xm-spotify-sync/network-policy.yaml</automated>
+    <automated>grep "network-policy.yaml" /home/santi/projects/HomeLab-Pro/apps/base/homepage/kustomization.yaml</automated>
+    <automated>grep "network-policy.yaml" /home/santi/projects/HomeLab-Pro/apps/base/xm-spotify-sync/kustomization.yaml</automated>
+    <automated>grep "kubernetes.io/metadata.name: kube-system" /home/santi/projects/HomeLab-Pro/apps/base/homepage/network-policy.yaml</automated>
+    <automated>grep "port: 22111" /home/santi/projects/HomeLab-Pro/apps/base/xm-spotify-sync/network-policy.yaml</automated>
+    <automated>grep "port: 22112" /home/santi/projects/HomeLab-Pro/apps/base/xm-spotify-sync/network-policy.yaml</automated>
+  </verify>
+
+  <acceptance_criteria>
+    - `grep -c "kind: NetworkPolicy" apps/base/homepage/network-policy.yaml` returns `2`
+    - `grep -c "kind: NetworkPolicy" apps/base/xm-spotify-sync/network-policy.yaml` returns `2`
+    - `grep "network-policy.yaml" apps/base/homepage/kustomization.yaml` exits 0
+    - `grep "network-policy.yaml" apps/base/xm-spotify-sync/kustomization.yaml` exits 0
+    - homepage file contains `kubernetes.io/metadata.name: kube-system` (Traefik cross-namespace allow)
+    - homepage file contains `app.kubernetes.io/name: traefik` as podSelector label
+    - xm-spotify-sync file contains both `port: 22111` AND `port: 22112` (dual-port — easy to miss second port)
+    - In both files the Traefik allow rule has namespaceSelector and podSelector as siblings in the SAME from entry (AND, not OR)
+    - `kustomize build apps/base/homepage/` exits 0
+    - `kustomize build apps/base/xm-spotify-sync/` exits 0
+  </acceptance_criteria>
+
+  <done>homepage and xm-spotify-sync network-policy.yaml created with Traefik allow rules, wired into kustomizations, kustomize build passes.</done>
+</task>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <what-built>
+NetworkPolicies applied across all 8 app namespaces via GitOps (FluxCD). This checkpoint verifies:
+1. All app pods still Running (no broken allow rules)
+2. Cross-namespace isolation works (mealie cannot reach linkding postgres)
+3. flux-system NetworkPolicies are untouched (SEC-05)
+4. All 8 namespaces have default-deny-ingress
+
+Merge the feature branch to main first so FluxCD applies the policies. Then run verification commands.
+  </what-built>
+  <how-to-verify>
+**Step 1 — Merge and wait for FluxCD sync (~1 min):**
+```bash
+flux reconcile kustomization apps --with-source
+kubectl get pods --all-namespaces | grep -v Running | grep -v Completed | grep -v Terminating
+# Expected: no output (all pods Running)
+```
+
+**Step 2 — Verify default-deny-ingress in all 8 namespaces (SEC-03):**
+```bash
+kubectl get networkpolicies --all-namespaces | grep default-deny-ingress | wc -l
+# Expected: 8
+```
+
+**Step 3 — Verify flux-system policies untouched (SEC-05):**
+```bash
+kubectl get networkpolicies -n flux-system
+# Expected: exactly 3 rows — allow-egress, allow-scraping, allow-webhooks
+```
+
+**Step 4 — Cross-namespace isolation test (SEC-04):**
+```bash
+kubectl run isolation-test --image=busybox --rm --restart=Never -n mealie \
+  -- nc -zvw3 linkding-postgres-rw.linkding.svc.cluster.local 5432
+# Expected: exits non-zero, "connection refused" or timeout — proves isolation
+# If exits 0: isolation is BROKEN — investigate allow-pgadmin rules in linkding/n8n
+```
+
+**Step 5 — Verify legitimate access works (SEC-04):**
+```bash
+kubectl run access-test --image=busybox --rm --restart=Never -n linkding \
+  -- nc -zvw3 linkding-postgres-rw 5432
+# Expected: exits 0 — linkding can still reach its own postgres
+```
+
+**Step 6 — Verify policy counts per namespace:**
+```bash
+for ns in linkding n8n mealie audiobookshelf pgadmin homepage xm-spotify-sync filebrowser; do
+  count=$(kubectl get networkpolicies -n $ns --no-headers 2>/dev/null | wc -l)
+  echo "$ns: $count policies"
+done
+# Expected: linkding=6, n8n=6, mealie=2, audiobookshelf=2, pgadmin=2, homepage=2, xm-spotify-sync=2, filebrowser=2
+```
+  </how-to-verify>
+  <resume-signal>Type "approved" if all 6 steps passed. Describe any failures (which step, which namespace) so they can be diagnosed and fixed.</resume-signal>
+</task>
+
+</tasks>
+
+<verification>
+Verification is performed in the checkpoint task above. The complete check suite:
+- All pods Running after policy apply
+- 8 default-deny-ingress policies visible across namespaces
+- flux-system shows exactly 3 policies (allow-egress, allow-scraping, allow-webhooks)
+- mealie isolation test exits non-zero (isolation working)
+- linkding self-access test exits 0 (legitimate access preserved)
+- Policy counts per namespace: 6 for linkding/n8n, 2 for all others
+</verification>
+
+<success_criteria>
+- homepage and xm-spotify-sync network-policy.yaml files exist with Traefik cross-namespace allow rules
+- xm-spotify-sync allows both port 22111 and 22112
+- All 8 app namespaces have default-deny-ingress after FluxCD applies
+- flux-system NetworkPolicies are exactly allow-egress, allow-scraping, allow-webhooks (unchanged)
+- mealie cannot reach linkding-postgres-rw.linkding.svc.cluster.local:5432
+- linkding can reach its own postgres (linkding-postgres-rw:5432)
+- All app pods Running after policy apply
+- Human approves checkpoint
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/10-networkpolicies-per-namespace-isolation/10-03-SUMMARY.md`
+</output>

--- a/.planning/phases/10-networkpolicies-per-namespace-isolation/10-RESEARCH.md
+++ b/.planning/phases/10-networkpolicies-per-namespace-isolation/10-RESEARCH.md
@@ -1,0 +1,582 @@
+# Phase 10: NetworkPolicies — Per-Namespace Isolation - Research
+
+**Researched:** 2026-04-11
+**Domain:** Kubernetes NetworkPolicy, Cilium CNI, CloudNativePG isolation
+**Confidence:** HIGH
+
+## Summary
+
+Phase 10 adds ingress-only default-deny NetworkPolicies to all 8 active app namespaces (linkding, n8n, mealie, audiobookshelf, pgadmin, homepage, xm-spotify-sync, filebrowser) and explicit allow-rules for every legitimate traffic flow. Cilium 1.16.19 is already installed as CNI and fully enforces standard `networking.k8s.io/v1` NetworkPolicy objects — no CiliumNetworkPolicy CRDs are needed for this scope. flux-system already has 3 NetworkPolicies (`allow-egress`, `allow-scraping`, `allow-webhooks`) that must not be touched (SEC-05).
+
+The scope is **ingress-only default-deny** — egress is not restricted. This preserves n8n's ability to make HTTP calls to external services, apps' DNS resolution, and all outbound traffic without any additional policy. The isolation goal is enforced purely by controlling what can REACH each pod: a rogue pod like mealie cannot initiate a TCP connection to `linkding-postgres-rw.linkding.svc.cluster.local:5432` because the postgres pod's ingress rules only permit traffic from the linkding app pod, the cnpg-system operator, the monitoring Prometheus pod, and the pgadmin admin pod.
+
+CloudNativePG (CNPG) introduces two critical ingress requirements not obvious from the app itself: the CNPG operator (in `cnpg-system` namespace) must reach postgres pods on **port 8000** (status API) and **port 5432** (postgres), and Prometheus must reach postgres pods on **port 9187** (metrics exporter) because a PodMonitor with `namespaceSelector: any: true` currently scrapes CNPG pods across all namespaces.
+
+**Primary recommendation:** Write all NetworkPolicies in `apps/base/{app}/network-policy.yaml` (added to each base kustomization) so they deploy alongside the app in the same kustomize build, except the CNPG-specific allow-operator policy which can also live in `apps/base/linkding/` and `apps/base/n8n/` since those namespaces host both the app and the CNPG cluster.
+
+<phase_requirements>
+## Phase Requirements
+
+| ID | Description | Research Support |
+|----|-------------|------------------|
+| SEC-03 | Default-deny NetworkPolicy applied in each app namespace | Standard `networking.k8s.io/v1` NetworkPolicy with empty podSelector and policyTypes: [Ingress]; 8 namespaces in scope |
+| SEC-04 | Allow-rules per namespace so each app can only reach its own database and required services | Full traffic matrix documented — all legitimate flows identified including CNPG operator access, Prometheus scraping, pgadmin cross-namespace DB admin |
+| SEC-05 | flux-system existing NetworkPolicies preserved and verified after Cilium migration | 3 existing policies confirmed in-place: `allow-egress`, `allow-scraping`, `allow-webhooks`; verification is a kubectl check, no changes needed |
+</phase_requirements>
+
+## Standard Stack
+
+### Core
+| Library | Version | Purpose | Why Standard |
+|---------|---------|---------|--------------|
+| networking.k8s.io/v1 NetworkPolicy | Built into K8s | L3/L4 pod ingress isolation | Native K8s API; Cilium enforces it via eBPF |
+| Cilium 1.16.19 | Already installed | CNI that enforces NetworkPolicy | Already deployed in Phase 9; standard eBPF datapath |
+
+### Supporting
+| Tool | Purpose | When to Use |
+|------|---------|-------------|
+| `kubectl run test-pod --image=busybox --rm -it --restart=Never -n mealie -- nc -zvw3 linkding-postgres-rw.linkding.svc.cluster.local 5432` | Isolation verification | Phase done-when test |
+| Hubble UI (hubble.watarystack.org) | Observe dropped flows in real-time | Debugging when allow-rule is missing |
+
+### Alternatives Considered
+| Instead of | Could Use | Tradeoff |
+|------------|-----------|----------|
+| networking.k8s.io/v1 | CiliumNetworkPolicy | Cilium CRD offers L7 rules; overkill for this scope; standard K8s policy portable across CNIs |
+| ingress-only default-deny | ingress+egress default-deny | Egress deny breaks n8n external webhooks, DNS, backup to R2; phase explicitly scopes to ingress-only |
+
+**Installation:** No new packages. All tooling already in cluster.
+
+## Architecture Patterns
+
+### Recommended File Structure
+```
+apps/base/{app}/
+├── deployment.yaml
+├── service.yaml
+├── namespace.yaml
+├── kustomization.yaml     ← add network-policy.yaml to resources
+└── network-policy.yaml    ← NEW: all NetworkPolicies for this namespace
+```
+
+One `network-policy.yaml` per app base directory containing multiple NetworkPolicy objects separated by `---`. Added as a `resources:` entry in the existing `apps/base/{app}/kustomization.yaml`.
+
+### Pattern 1: Default-Deny Ingress
+**What:** Blocks all ingress to all pods in the namespace unless an explicit allow rule matches.
+**When to use:** First policy in every app namespace.
+```yaml
+# Source: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+```
+
+### Pattern 2: Allow Same-Namespace Pod (cloudflared → app)
+**What:** Allows a specific labeled pod within the same namespace to reach an app pod.
+**When to use:** cloudflared → app service in all Cloudflare Tunnel namespaces.
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-cloudflared
+spec:
+  podSelector:
+    matchLabels:
+      app: linkding          # Target: the app pod
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: cloudflared   # Source: cloudflared in same namespace
+    ports:
+    - port: 9090
+      protocol: TCP
+```
+
+### Pattern 3: Allow Cross-Namespace (CNPG operator → postgres pods)
+**What:** Allows pods from a specific external namespace to reach pods in this namespace.
+**When to use:** cnpg-system operator → CNPG postgres pods; monitoring Prometheus → CNPG metrics.
+**Source:** https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/main/docs/src/samples/networkpolicy-example.yaml
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-cnpg-operator
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: linkding-postgres   # Target: CNPG pods only
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: cnpg-system
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: cloudnative-pg
+    ports:
+    - port: 8000    # CNPG status API (operator health checks)
+    - port: 5432    # PostgreSQL
+```
+
+### Pattern 4: Prometheus Scrape Allow (monitoring → CNPG metrics)
+**What:** Allows Prometheus pod to scrape metrics from CNPG postgres pods.
+**When to use:** Any namespace where Prometheus needs to scrape pods.
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-prometheus-scrape
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: linkding-postgres   # Target: CNPG pods
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: monitoring
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: prometheus
+    ports:
+    - port: 9187    # CNPG metrics exporter (named port: "metrics")
+```
+
+### Pattern 5: Allow Traefik Ingress (kube-system → app)
+**What:** Allows Traefik (in kube-system) to route HTTP/HTTPS to an app pod.
+**When to use:** homepage and xm-spotify-sync (use Traefik Ingress, not Cloudflare Tunnel).
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-traefik
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: homepage
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: traefik
+    ports:
+    - port: 3000
+```
+
+### Anti-Patterns to Avoid
+- **`namespaceSelector` alone without `podSelector`:** Allows ALL pods in the namespace, not just the intended ones. Use both together in the same `from` entry for AND semantics.
+- **Separate `namespaceSelector` and `podSelector` list entries:** Creates OR logic — allows any pod matching EITHER selector. Use a single object `{namespaceSelector: ..., podSelector: ...}` for AND.
+- **Forgetting CNPG port 8000:** The CNPG operator queries postgres pods on port 8000 (status API) — missing this allows app isolation but breaks operator health checks.
+- **Omitting CNPG metrics port 9187:** The PodMonitor `cloudnativepg-pods` in the monitoring namespace has `namespaceSelector: any: true` and scrapes port 9187. Missing this silently kills CNPG metrics in Grafana.
+
+## Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| Isolation testing | Custom network diagnostic deployment | `kubectl run --image=busybox --rm -it` one-liner | Ephemeral pod; no cleanup overhead |
+| Flow visibility | Manual tcpdump | Hubble UI at hubble.watarystack.org | Already deployed; shows AUDIT/DROP verdicts by namespace |
+| Policy validation | Manual trace | `cilium connectivity test` or Hubble observe | Cilium provides built-in network flow audit mode |
+
+**Key insight:** Hubble (deployed in Phase 9) is the correct tool for NetworkPolicy debugging. When a policy is too restrictive, Hubble shows dropped flows with source namespace, destination, and port — eliminating guesswork.
+
+## Complete Traffic Matrix
+
+This table is the authoritative source for all allow-rules needed.
+
+### linkding namespace
+| Source | Destination Pod | Port | Protocol | Rule Name |
+|--------|----------------|------|----------|-----------|
+| same-ns `app=cloudflared` | `app=linkding` | 9090 | TCP | allow-cloudflared |
+| same-ns `app=linkding` | `cnpg.io/cluster=linkding-postgres` | 5432 | TCP | allow-app-to-postgres |
+| `cnpg-system` / `app.kubernetes.io/name=cloudnative-pg` | `cnpg.io/cluster=linkding-postgres` | 8000, 5432 | TCP | allow-cnpg-operator |
+| `monitoring` / `app.kubernetes.io/name=prometheus` | `cnpg.io/cluster=linkding-postgres` | 9187 | TCP | allow-prometheus-scrape |
+| `pgadmin` ns (any pod) | `cnpg.io/cluster=linkding-postgres` | 5432 | TCP | allow-pgadmin |
+
+### n8n namespace
+| Source | Destination Pod | Port | Protocol | Rule Name |
+|--------|----------------|------|----------|-----------|
+| same-ns `app=cloudflared` | `app=n8n` | 5678 | TCP | allow-cloudflared |
+| same-ns `app=n8n` | `cnpg.io/cluster=n8n-postgresql-cluster` | 5432 | TCP | allow-app-to-postgres |
+| `cnpg-system` / `app.kubernetes.io/name=cloudnative-pg` | `cnpg.io/cluster=n8n-postgresql-cluster` | 8000, 5432 | TCP | allow-cnpg-operator |
+| `monitoring` / `app.kubernetes.io/name=prometheus` | `cnpg.io/cluster=n8n-postgresql-cluster` | 9187 | TCP | allow-prometheus-scrape |
+| `pgadmin` ns (any pod) | `cnpg.io/cluster=n8n-postgresql-cluster` | 5432 | TCP | allow-pgadmin |
+
+### mealie namespace
+| Source | Destination Pod | Port | Protocol | Rule Name |
+|--------|----------------|------|----------|-----------|
+| same-ns `app=cloudflared` | `app=mealie` | 9000 | TCP | allow-cloudflared |
+
+### audiobookshelf namespace
+| Source | Destination Pod | Port | Protocol | Rule Name |
+|--------|----------------|------|----------|-----------|
+| same-ns `app=cloudflared` | `app=audiobookshelf` | 3005 | TCP | allow-cloudflared |
+
+### pgadmin namespace
+| Source | Destination Pod | Port | Protocol | Rule Name |
+|--------|----------------|------|----------|-----------|
+| same-ns `app=cloudflared` | `app=pgadmin` | 80 | TCP | allow-cloudflared |
+
+### homepage namespace
+| Source | Destination Pod | Port | Protocol | Rule Name |
+|--------|----------------|------|----------|-----------|
+| `kube-system` / `app.kubernetes.io/name=traefik` | `app.kubernetes.io/name=homepage` | 3000 | TCP | allow-traefik |
+
+### xm-spotify-sync namespace
+| Source | Destination Pod | Port | Protocol | Rule Name |
+|--------|----------------|------|----------|-----------|
+| `kube-system` / `app.kubernetes.io/name=traefik` | `app=xm-spotify-sync` | 22111, 22112 | TCP | allow-traefik |
+
+### filebrowser namespace
+| Source | Destination Pod | Port | Protocol | Rule Name |
+|--------|----------------|------|----------|-----------|
+| same-ns `app=cloudflared` | `app=filebrowser` | 8088 | TCP | allow-cloudflared |
+
+## Key Facts About the Existing Cluster
+
+### Namespace Labels (kubernetes.io/metadata.name is auto-set since K8s 1.21)
+| Namespace | Stable Selector Label | Use In |
+|-----------|----------------------|--------|
+| `monitoring` | `kubernetes.io/metadata.name: monitoring` | Prometheus scrape allow rules |
+| `cnpg-system` | `kubernetes.io/metadata.name: cnpg-system` | CNPG operator allow rules |
+| `kube-system` | `kubernetes.io/metadata.name: kube-system` | Traefik ingress allow rules |
+| `pgadmin` | `kubernetes.io/metadata.name: pgadmin` | pgadmin cross-namespace DB access |
+
+### Pod Labels (verified live)
+| Pod | Key Labels | Used In |
+|-----|-----------|---------|
+| cloudflared | `app=cloudflared` | Source in all Cloudflare Tunnel namespace rules |
+| linkding app | `app=linkding` | Source in linkding postgres allow rule |
+| n8n app | `app=n8n` | Source in n8n postgres allow rule |
+| linkding CNPG | `cnpg.io/cluster=linkding-postgres` | Target in linkding postgres rules |
+| n8n CNPG | `cnpg.io/cluster=n8n-postgresql-cluster` | Target in n8n postgres rules |
+| Prometheus | `app.kubernetes.io/name=prometheus` | Source in prometheus scrape rules |
+| CNPG operator | `app.kubernetes.io/name=cloudnative-pg` | Source in CNPG operator rules |
+| Traefik | `app.kubernetes.io/name=traefik` | Source in Traefik ingress rules |
+
+### Existing flux-system NetworkPolicies (DO NOT MODIFY — SEC-05)
+| Name | Effect |
+|------|--------|
+| `allow-egress` | All pods in flux-system can send egress AND receive intra-namespace ingress |
+| `allow-scraping` | Any namespace can reach port 8080 on any flux-system pod |
+| `allow-webhooks` | Any namespace can reach `app=notification-controller` pods on any port |
+
+### Traffic NOT affected by ingress-only default-deny
+- Kubelet liveness/readiness probes (host network, exempt from NetworkPolicy)
+- cloudflared outbound tunnel connections to Cloudflare edge (egress — not restricted)
+- n8n HTTP calls to external APIs (egress — not restricted)
+- R2 backup traffic from CNPG (egress — not restricted)
+- DNS resolution by all pods (egress UDP/53 to kube-system coredns — not restricted)
+- node-exporter metrics scraping (host network pods bypass NetworkPolicy)
+
+### Out-of-Scope Namespaces (not getting default-deny in this phase)
+`monitoring`, `longhorn-system`, `cnpg-system`, `cert-manager`, `kube-system`, `renovate`, `flux-system`
+
+## Common Pitfalls
+
+### Pitfall 1: AND vs OR in `from` selectors
+**What goes wrong:** Two separate list items (one `namespaceSelector`, one `podSelector`) create OR logic — allows any pod in the namespace OR any pod with that label anywhere.
+**Why it happens:** YAML list syntax; many tutorials show this incorrectly.
+**How to avoid:** Put both selectors in the SAME list entry object for AND semantics.
+```yaml
+# WRONG (OR logic — allows all pods in monitoring namespace):
+ingress:
+- from:
+  - namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: monitoring
+  - podSelector:
+      matchLabels:
+        app.kubernetes.io/name: prometheus
+
+# CORRECT (AND logic — only prometheus pods in monitoring namespace):
+ingress:
+- from:
+  - namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: monitoring
+    podSelector:
+      matchLabels:
+        app.kubernetes.io/name: prometheus
+```
+**Warning signs:** mealie can reach linkding postgres after policies are applied.
+
+### Pitfall 2: Missing CNPG Port 8000
+**What goes wrong:** CNPG operator cannot perform health checks; cluster goes into Unknown state; backup WAL archiving eventually stalls.
+**Why it happens:** Port 5432 is obvious; port 8000 (CNPG status API) is CNPG-specific and not documented in standard postgres setup guides.
+**How to avoid:** Always include both ports 8000 and 5432 in the allow-cnpg-operator rule.
+**Warning signs:** `kubectl get cluster -n linkding` shows status Unknown or unreconciled.
+
+### Pitfall 3: Missing CNPG Metrics Port 9187
+**What goes wrong:** Grafana CNPG dashboards show "No data"; PodMonitor `cloudnativepg-pods` stops collecting.
+**Why it happens:** PodMonitor uses `namespaceSelector: any: true` to scrape all namespaces — but NetworkPolicy blocks Prometheus ingress to port 9187.
+**How to avoid:** Include port 9187 in the allow-prometheus-scrape rule targeting CNPG pods.
+**Warning signs:** Prometheus targets page shows postgres pods as DOWN on port 9187.
+
+### Pitfall 4: Forgetting pgadmin Cross-Namespace DB Access
+**What goes wrong:** pgadmin UI fails to connect to either postgres cluster; users lose DB admin capability.
+**Why it happens:** pgadmin stores server connection configs in its PVC and connects across namespaces — this cross-namespace traffic goes through the ingress of linkding/n8n namespaces.
+**How to avoid:** Add a `allow-pgadmin` ingress rule in both linkding and n8n namespaces allowing traffic from the `pgadmin` namespace on port 5432.
+**Warning signs:** pgadmin shows "connection refused" or timeout when connecting to registered servers.
+
+### Pitfall 5: Applying Default-Deny Before Allow Rules
+**What goes wrong:** Brief outage between default-deny apply and allow rule apply — existing connections (CNPG replication, app→db connections) drop.
+**Why it happens:** Kustomize applies resources in order but reconciliation may not be atomic.
+**How to avoid:** Include all policies (default-deny + all allow rules) in the same `network-policy.yaml` file. Kustomize builds them as a single batch. FluxCD applies atomically.
+**Warning signs:** App pod CrashLoopBackOff immediately after policy apply.
+
+### Pitfall 6: xm-spotify-sync has dual-port Traefik ingress
+**What goes wrong:** Only one of the two ports (frontend 22111 or backend 22112) gets the allow rule.
+**Why it happens:** Most apps have a single port; xm-spotify-sync is the exception.
+**How to avoid:** Allow both ports 22111 and 22112 in the traefik allow rule for xm-spotify-sync.
+**Warning signs:** Frontend loads but API calls fail (or vice versa).
+
+## Code Examples
+
+### Verified: linkding complete network-policy.yaml
+```yaml
+# Source: Official K8s NetworkPolicy API + CNPG networking docs
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-cloudflared
+spec:
+  podSelector:
+    matchLabels:
+      app: linkding
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: cloudflared
+    ports:
+    - port: 9090
+      protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-app-to-postgres
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: linkding-postgres
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: linkding
+    ports:
+    - port: 5432
+      protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-cnpg-operator
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: linkding-postgres
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: cnpg-system
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: cloudnative-pg
+    ports:
+    - port: 8000
+      protocol: TCP
+    - port: 5432
+      protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-prometheus-scrape
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: linkding-postgres
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: monitoring
+      podSelector:
+        matchLabels:
+          app.kubernetes.io/name: prometheus
+    ports:
+    - port: 9187
+      protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-pgadmin
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/cluster: linkding-postgres
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: pgadmin
+    ports:
+    - port: 5432
+      protocol: TCP
+```
+
+### Isolation Test Command
+```bash
+# Expected result: FAILS (connection refused or timeout) — proves isolation works
+kubectl run isolation-test --image=busybox --rm -it --restart=Never -n mealie \
+  -- nc -zvw3 linkding-postgres-rw.linkding.svc.cluster.local 5432
+
+# Verify legitimate access still works (should SUCCEED):
+kubectl run access-test --image=busybox --rm -it --restart=Never -n linkding \
+  -- nc -zvw3 linkding-postgres-rw 5432
+```
+
+### Verify flux-system Policies Intact (SEC-05)
+```bash
+kubectl get networkpolicies -n flux-system
+# Expected: allow-egress, allow-scraping, allow-webhooks — exactly 3, unchanged
+```
+
+## State of the Art
+
+| Old Approach | Current Approach | Impact |
+|--------------|-----------------|--------|
+| Flannel (no NetworkPolicy enforcement) | Cilium 1.16 eBPF | NetworkPolicy now actually enforced |
+| No namespace isolation | Default-deny + explicit allows | Zero-trust pod-to-pod posture |
+
+**Key:** Cilium was installed in Phase 9. Without Cilium (or another NetworkPolicy-capable CNI), creating NetworkPolicy objects would have been silently ignored by Flannel. Flannel does not enforce NetworkPolicy.
+
+## Open Questions
+
+1. **Should pgadmin's cross-namespace DB access be tightened to specific pod labels?**
+   - What we know: pgadmin is in pgadmin namespace; connects to linkding-postgres and n8n-postgresql-cluster via stored PVC sessions
+   - What's unclear: Are there pod labels stable enough on pgadmin to use `podSelector` to restrict which pods in pgadmin ns can reach postgres?
+   - Recommendation: Use `namespaceSelector: pgadmin` only (no podSelector) — pgadmin only has one pod anyway, and it simplifies the rule. If pgadmin namespace ever contains untrusted pods, revisit.
+
+2. **Should monitoring namespace get a default-deny policy in this phase?**
+   - What we know: The phase scope says "each app namespace" — monitoring is infrastructure
+   - What's unclear: Phase scope is ambiguous on whether Grafana/AlertManager/Prometheus need isolation
+   - Recommendation: Exclude monitoring from this phase; document as potential Phase 11+ hardening.
+
+## Environment Availability
+
+| Dependency | Required By | Available | Version | Fallback |
+|------------|------------|-----------|---------|----------|
+| Cilium CNI | NetworkPolicy enforcement | Yes | 1.16.19 | — |
+| kubectl | Apply/verify policies | Yes | K8s 1.30 API | — |
+| busybox image | Isolation test pod | Yes (public registry) | latest | nicolaka/netshoot |
+| Hubble UI | Flow debugging | Yes | hubble.watarystack.org | `cilium status` CLI |
+| FluxCD | GitOps apply | Yes | v2.5.1 | kubectl apply -k |
+
+**Missing dependencies with no fallback:** None.
+
+## Validation Architecture
+
+### Test Framework
+| Property | Value |
+|----------|-------|
+| Framework | kubectl one-shot test pods (no automated test framework — infrastructure change) |
+| Config file | none |
+| Quick run command | `kubectl run isolation-test --image=busybox --rm -it --restart=Never -n mealie -- nc -zvw3 linkding-postgres-rw.linkding.svc.cluster.local 5432` |
+| Full suite command | See Phase Requirements → Test Map below |
+
+### Phase Requirements → Test Map
+
+| Req ID | Behavior | Test Type | Automated Command | File Exists? |
+|--------|----------|-----------|-------------------|-------------|
+| SEC-03 | default-deny-ingress exists in all 8 app namespaces | smoke | `kubectl get networkpolicies --all-namespaces \| grep default-deny-ingress \| wc -l` (expect 8) | n/a — kubectl check |
+| SEC-04 | mealie cannot reach linkding postgres | isolation | `kubectl run test --image=busybox --rm --restart=Never -n mealie -- nc -zvw3 linkding-postgres-rw.linkding.svc.cluster.local 5432; [ $? -ne 0 ] && echo PASS || echo FAIL` | n/a — kubectl check |
+| SEC-04 | linkding app CAN reach its own postgres | access | `kubectl run test --image=busybox --rm --restart=Never -n linkding -- nc -zvw3 linkding-postgres-rw 5432; [ $? -eq 0 ] && echo PASS || echo FAIL` | n/a — kubectl check |
+| SEC-04 | n8n app CAN reach its own postgres | access | `kubectl run test --image=busybox --rm --restart=Never -n n8n -- nc -zvw3 n8n-postgresql-cluster-rw 5432; [ $? -eq 0 ] && echo PASS || echo FAIL` | n/a — kubectl check |
+| SEC-04 | All app pods Running after policies apply | smoke | `kubectl get pods --all-namespaces \| grep -v Running \| grep -v Completed` | n/a — kubectl check |
+| SEC-05 | flux-system has exactly 3 NetworkPolicies | smoke | `kubectl get networkpolicies -n flux-system \| grep -c "allow-"` (expect 3) | n/a — kubectl check |
+
+### Sampling Rate
+- **Per task commit:** `kubectl get pods --all-namespaces | grep -v Running | grep -v Completed` (verify no pods in Error/CrashLoop)
+- **Per wave merge:** Full isolation test suite from the table above
+- **Phase gate:** All 6 test checks pass before `/gsd:verify-work`
+
+### Wave 0 Gaps
+None — existing infrastructure covers all phase requirements. No test framework to install.
+
+## Sources
+
+### Primary (HIGH confidence)
+- Kubernetes official docs — NetworkPolicy API, default-deny patterns, AND vs OR selector semantics: https://kubernetes.io/docs/concepts/services-networking/network-policies/
+- CloudNativePG official networking docs — port 8000 + 5432 operator requirement, example networkpolicy-example.yaml: https://cloudnative-pg.io/docs/devel/networking/
+- CloudNativePG GitHub sample manifest (verified YAML): https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/main/docs/src/samples/networkpolicy-example.yaml
+- Live cluster introspection — namespace labels, pod labels, existing NetworkPolicies, service ports (kubectl output 2026-04-11)
+
+### Secondary (MEDIUM confidence)
+- Cilium docs on NetworkPolicy enforcement modes: https://docs.cilium.io/en/stable/network/kubernetes/policy/
+- CNCF blog — safe Cilium policy management and Hubble audit mode: https://www.cncf.io/blog/2025/11/06/safely-managing-cilium-network-policies-in-kubernetes-testing-and-simulation-techniques/
+
+### Tertiary (LOW confidence)
+- General NetworkPolicy best practices (Azure AKS docs — different platform but same K8s API): https://learn.microsoft.com/en-us/azure/aks/network-policy-best-practices
+
+## Metadata
+
+**Confidence breakdown:**
+- Standard stack: HIGH — Cilium 1.16 installed, standard K8s NetworkPolicy API confirmed working
+- Traffic matrix: HIGH — all pod labels, namespace labels, service ports verified live against cluster
+- CNPG requirements: HIGH — confirmed against official CNPG networking docs + live port verification
+- Architecture (file placement): HIGH — follows established base/overlay convention in this repo
+- Pitfalls: HIGH — AND/OR selector behavior is K8s documented; port 8000 confirmed from CNPG docs + live pod spec
+
+**Research date:** 2026-04-11
+**Valid until:** 2026-05-11 (stable K8s API; CNPG operator label `app.kubernetes.io/name=cloudnative-pg` stable)
+
+## Project Constraints (from CLAUDE.md)
+
+| Directive | Impact on This Phase |
+|-----------|---------------------|
+| Follow base/overlay pattern | NetworkPolicy files go in `apps/base/{app}/network-policy.yaml`, referenced in base kustomization |
+| Never commit unencrypted secrets | Not applicable — NetworkPolicy objects contain no secrets |
+| Branch from main, never commit to main | Create `feat/phase-10-networkpolicies` branch |
+| Test with `kubectl apply -k ... --dry-run=client` first | Validate each namespace kustomization before commit |
+| All secrets SOPS-encrypted | Not applicable — NetworkPolicy objects are not secrets |
+| Add new apps to Homepage dashboard | Not applicable — no new apps in this phase |

--- a/.planning/phases/10-networkpolicies-per-namespace-isolation/10-VALIDATION.md
+++ b/.planning/phases/10-networkpolicies-per-namespace-isolation/10-VALIDATION.md
@@ -1,0 +1,76 @@
+---
+phase: 10
+slug: networkpolicies-per-namespace-isolation
+status: draft
+nyquist_compliant: true
+wave_0_complete: false
+created: 2026-04-11
+---
+
+# Phase 10 — Validation Strategy
+
+> Per-phase validation contract for feedback sampling during execution.
+
+---
+
+## Test Infrastructure
+
+| Property | Value |
+|----------|-------|
+| **Framework** | kubectl (cluster verification scripts) |
+| **Config file** | none — kubectl commands used directly |
+| **Quick run command** | `kubectl get networkpolicies --all-namespaces` |
+| **Full suite command** | `kubectl get networkpolicies --all-namespaces && kubectl run test-isolation --image=busybox --rm -it --restart=Never -- sh` |
+| **Estimated runtime** | ~30 seconds |
+
+---
+
+## Sampling Rate
+
+- **After every task commit:** Run `kubectl get networkpolicies --all-namespaces`
+- **After every plan wave:** Run full suite command above
+- **Before `/gsd:verify-work`:** Full suite must be green
+- **Max feedback latency:** 30 seconds
+
+---
+
+## Per-Task Verification Map
+
+| Task ID | Plan | Wave | Requirement | Test Type | Automated Command | File Exists | Status |
+|---------|------|------|-------------|-----------|-------------------|-------------|--------|
+| 10-01-01 | 01 | 1 | SEC-03 | infra | `kubectl get networkpolicy default-deny-ingress -n linkding` | ✅ | ⬜ pending |
+| 10-01-02 | 01 | 1 | SEC-03 | infra | `kubectl get networkpolicy default-deny-ingress -n n8n` | ✅ | ⬜ pending |
+| 10-01-03 | 01 | 1 | SEC-04 | infra | `kubectl get networkpolicy allow-app-to-postgres -n linkding` | ✅ | ⬜ pending |
+| 10-01-04 | 01 | 1 | SEC-04 | infra | `kubectl get networkpolicy allow-app-to-postgres -n n8n` | ✅ | ⬜ pending |
+| 10-02-01 | 02 | 1 | SEC-04 | infra | `kubectl get networkpolicy allow-prometheus-scrape -n linkding` | ✅ | ⬜ pending |
+| 10-03-01 | 03 | 3 | SEC-05 | manual | Cross-namespace block test via test pod | ⚠️ manual | ⬜ pending |
+
+*Status: ⬜ pending · ✅ green · ❌ red · ⚠️ flaky*
+
+---
+
+## Wave 0 Requirements
+
+*Existing infrastructure covers all phase requirements — kubectl available, cluster accessible.*
+
+---
+
+## Manual-Only Verifications
+
+| Behavior | Requirement | Why Manual | Test Instructions |
+|----------|-------------|------------|-------------------|
+| mealie cannot reach linkding's postgres | SEC-05 | Requires spawning test pod and running connection attempt | `kubectl run test-pod --image=busybox --rm -it --restart=Never -n mealie -- nc -zv linkding-postgres-rw.linkding.svc.cluster.local 5432; expect connection refused` |
+| Cross-namespace DB access is blocked | SEC-05 | Same as above — live cluster verification | Run test pod from non-authorized namespace, verify timeout/refused |
+
+---
+
+## Validation Sign-Off
+
+- [ ] All tasks have `<automated>` verify or Wave 0 dependencies
+- [ ] Sampling continuity: no 3 consecutive tasks without automated verify
+- [ ] Wave 0 covers all MISSING references
+- [ ] No watch-mode flags
+- [ ] Feedback latency < 30s
+- [ ] `nyquist_compliant: true` set in frontmatter
+
+**Approval:** pending


### PR DESCRIPTION
## Summary

- Reorganized homepage into categories with improved layout and glassmorphism CSS styling
- Added Prometheus and AlertManager dashboard links to homepage
- Added 5 official Grafana dashboards (Cilium, FluxCD cluster/control-plane, Longhorn, Traefik)
- Updated GSD planning tracking: marked phases 1-9 as complete in ROADMAP.md and STATE.md

## Phase tracking changes

All phases 1-9 are now reflected as complete:
- Phase 1: Fix FluxCD Bootstrap Race
- Phase 2: Resource Limits — audiobookshelf
- Phase 3: Grafana Admin Password as SOPS Secret
- Phase 4: n8n Database Backup
- Phase 5: Fix linkding Backup Destination
- Phase 6: Install Longhorn Distributed Storage
- Phase 7: Migrate PVCs to Longhorn
- Phase 8: Balance Workloads to Worker Nodes
- Phase 9: Cilium CNI Migration

## Test plan

- [ ] Homepage loads at configured URL with updated layout
- [ ] Grafana dashboards appear and load data (Cilium, FluxCD, Longhorn, Traefik)
- [ ] Prometheus and AlertManager links are accessible from homepage
- [ ] `flux get kustomizations` shows all kustomizations healthy after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)