### PR TITLE
fix(monitoring): add missing metrics Services for Traefik and Cilium dashboards

### DIFF
--- a/monitoring/configs/staging/kube-prometheus-stack/cilium-metrics-services.yaml
+++ b/monitoring/configs/staging/kube-prometheus-stack/cilium-metrics-services.yaml
@@ -1,0 +1,33 @@
+---
+# Headless Service for Cilium agent metrics (DaemonSet)
+apiVersion: v1
+kind: Service
+metadata:
+  name: cilium-agent-metrics
+  namespace: kube-system
+  labels:
+    k8s-app: cilium
+spec:
+  clusterIP: None
+  selector:
+    k8s-app: cilium
+  ports:
+    - name: metrics
+      port: 9962
+      targetPort: prometheus
+---
+# Service for Cilium operator metrics
+apiVersion: v1
+kind: Service
+metadata:
+  name: cilium-operator-metrics
+  namespace: kube-system
+  labels:
+    io.cilium/app: operator
+spec:
+  selector:
+    io.cilium/app: operator
+  ports:
+    - name: metrics
+      port: 9963
+      targetPort: prometheus

--- a/monitoring/configs/staging/kube-prometheus-stack/kustomization.yaml
+++ b/monitoring/configs/staging/kube-prometheus-stack/kustomization.yaml
@@ -4,8 +4,10 @@ resources:
   - grafana-tls-secret.yaml
   - cloudnativepg-podmonitor.yaml
   - cilium-servicemonitor.yaml
+  - cilium-metrics-services.yaml
   - fluxcd-podmonitor.yaml
   - traefik-servicemonitor.yaml
+  - traefik-metrics-service.yaml
   - prometheus-rbac.yaml
   - grafana-admin-secret.yaml
   - prometheus-ingress.yaml

--- a/monitoring/configs/staging/kube-prometheus-stack/traefik-metrics-service.yaml
+++ b/monitoring/configs/staging/kube-prometheus-stack/traefik-metrics-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: traefik-metrics
+  namespace: kube-system
+  labels:
+    app.kubernetes.io/name: traefik
+spec:
+  selector:
+    app.kubernetes.io/name: traefik
+  ports:
+    - name: metrics
+      port: 9100
+      targetPort: metrics


### PR DESCRIPTION
## Summary

- **Traefik dashboard had no data**: The `traefik` Service in `kube-system` only exposed `web`/`websecure` ports — no `metrics` port. Added `traefik-metrics` Service exposing port 9100 so the ServiceMonitor can discover scrape targets.
- **Cilium dashboard had no data**: No Kubernetes Service existed for Cilium agent (port 9962) or operator (port 9963) metrics. Added `cilium-agent-metrics` (headless) and `cilium-operator-metrics` Services so the ServiceMonitors can discover pod endpoints.
- **FluxCD and Longhorn dashboards**: Already working — no changes needed.

**Root cause**: ServiceMonitors require Kubernetes Services to discover pod IPs. Without matching Services exposing a `metrics`-named port, Prometheus had zero endpoints to scrape for Traefik and Cilium.

## Files Changed

- `monitoring/configs/staging/kube-prometheus-stack/traefik-metrics-service.yaml` — new
- `monitoring/configs/staging/kube-prometheus-stack/cilium-metrics-services.yaml` — new
- `monitoring/configs/staging/kube-prometheus-stack/kustomization.yaml` — added both files

## Test plan

- [ ] Merge and wait ~2 min for FluxCD to sync
- [ ] Verify Services created: `kubectl get svc -n kube-system traefik-metrics cilium-agent-metrics cilium-operator-metrics`
- [ ] Verify Prometheus targets are UP: check Prometheus UI → Targets, filter by `traefik` and `cilium`
- [ ] Verify Grafana Traefik and Cilium dashboards show data

🤖 Generated with [Claude Code](https://claude.com/claude-code)