### PR TITLE
feat(13): observability phase — Loki, Fluent Bit, Gatus, Hubble

### DIFF
--- a/apps/base/homepage/homepage-configmap.yaml
+++ b/apps/base/homepage/homepage-configmap.yaml
@@ -213,11 +213,6 @@ data:
             description: Distributed block storage management
             icon: longhorn.png
             ping: https://longhorn.watarystack.org
-        - Headlamp:
-            href: https://headlamp.watarystack.org
-            description: Kubernetes cluster dashboard
-            icon: kubernetes.png
-            ping: https://headlamp.watarystack.org
   widgets.yaml: |
     - kubernetes:
         cluster:

--- a/monitoring/configs/staging/kube-prometheus-stack/cilium-servicemonitor.yaml
+++ b/monitoring/configs/staging/kube-prometheus-stack/cilium-servicemonitor.yaml
@@ -16,6 +16,9 @@ spec:
     - port: metrics
       interval: 30s
       path: /metrics
+      metricRelabelings:
+        - targetLabel: k8s_app
+          replacement: cilium
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor


### PR DESCRIPTION
## Summary

- Deploys Loki (single-binary, filesystem, Longhorn PVC) + Fluent Bit DaemonSet for cluster-wide log collection
- Adds Loki datasource ConfigMap for Grafana sidecar auto-discovery
- Deploys Gatus status page with Cloudflare tunnel at `https://status.watarystack.org`
- Fixes Cilium Grafana dashboard showing no data (missing `k8s_app` label on scraped metrics)
- Removes duplicate Headlamp entry from homepage (was showing twice: once static, once via ingress annotation auto-discovery)

## Cilium dashboard fix

The dashboard panels query `cilium_forward_count_total{k8s_app="cilium", ...}` but the Prometheus scrape job (`cilium-agent-metrics`) was not propagating the `k8s_app` label onto metrics. Added a `metricRelabelings` rule to inject `k8s_app=cilium` on all metrics from the Cilium agent ServiceMonitor. After FluxCD reconciles, panels will start showing data within one scrape interval (~30s).

## Loki & Fluent Bit — where to see them

They are **not dashboards** — they're infrastructure components:
- **Loki** (`loki-0` in `monitoring`): log storage backend
- **Fluent Bit** (DaemonSet, one pod per node in `monitoring`): collects `/var/log/containers/*.log` and forwards to Loki

To browse logs → **Grafana → Explore → select "Loki" datasource** → use `{namespace="..."}` label filters.

## Test plan

- [ ] Cilium dashboard panels show data after next Prometheus scrape cycle
- [ ] Homepage shows Headlamp only once (in Infrastructure group, via annotation auto-discovery)
- [ ] `kubectl get pods -n monitoring` shows `loki-0` and `fluent-bit-*` pods Running
- [ ] Grafana Explore with Loki datasource returns log streams

🤖 Generated with [Claude Code](https://claude.com/claude-code)