### PR TITLE
fix(headlamp): resolve CrashLoopBackOff and TLS certificate

### DIFF
--- a/apps/base/headlamp/deployment.yaml
+++ b/apps/base/headlamp/deployment.yaml
@@ -32,6 +32,20 @@ spec:
         runAsGroup: 101
         fsGroup: 101
         runAsNonRoot: true
+      initContainers:
+        - name: copy-frontend
+          image: ghcr.io/headlamp-k8s/headlamp:v0.26.0
+          command: ["cp", "-r", "/headlamp/frontend/.", "/frontend-rw/"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: frontend-rw
+              mountPath: /frontend-rw
       containers:
         - name: headlamp
           image: ghcr.io/headlamp-k8s/headlamp:v0.26.0
@@ -59,6 +73,11 @@ spec:
             capabilities:
               drop:
                 - ALL
+          volumeMounts:
+            - name: config-dir
+              mountPath: /home/headlamp/.config
+            - name: frontend-rw
+              mountPath: /headlamp/frontend
           livenessProbe:
             httpGet:
               path: /
@@ -71,3 +90,8 @@ spec:
               port: 4466
             initialDelaySeconds: 10
             periodSeconds: 10
+      volumes:
+        - name: config-dir
+          emptyDir: {}
+        - name: frontend-rw
+          emptyDir: {}


### PR DESCRIPTION
## Summary

- **Headlamp CrashLoopBackOff**: Headlamp v0.26.0 writes `index.baseUrl.html` into `/headlamp/frontend` at startup and calls `os.Exit(1)` on failure. With `readOnlyRootFilesystem: true` both that path and `/home/headlamp/.config` were unwritable.
- **TLS**: cert-manager issued a valid cert for `headlamp.watarystack.org` but Traefik was still serving its fallback self-signed cert — restarted Traefik to force the TLS secret reload.

## Headlamp fix approach

Added an init container (`copy-frontend`) that runs before the main container and copies the baked-in `/headlamp/frontend/` into an `emptyDir` volume. The main container then mounts that writable volume at `/headlamp/frontend`. A second `emptyDir` is mounted at `/home/headlamp/.config` for the plugins directory.

`readOnlyRootFilesystem: true` and all other security hardening (drop ALL caps, runAsNonRoot, seccompProfile) are preserved.

## TLS fix

Restarted the Traefik deployment (`kubectl rollout restart deployment/traefik -n kube-system`) to force it to re-read the `headlamp-tls` secret. The cert was valid — Traefik just hadn't picked it up from its watch cache. This is a live cluster action; no manifest change needed.

## Test plan

- [ ] `kubectl get pods -n headlamp` shows `1/1 Running`
- [ ] `https://headlamp.watarystack.org` loads the Headlamp UI
- [ ] Gatus shows headlamp.watarystack.org TLS check as green
- [ ] No TLS warning in browser for headlamp.watarystack.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)