### PR TITLE
feat: complete phase 14 - PiHole network DNS & ad-blocking

### DIFF
--- a/.claude/skills/homelab-app-onboarding/SKILL.md
+++ b/.claude/skills/homelab-app-onboarding/SKILL.md
@@ -30,7 +30,7 @@ Ask the user for these details. If they've already provided some in the conversa
 | `APP_NAME` | `vaultwarden`, `paperless`, `stirling-pdf` | App identifier (lowercase, no spaces) |
 | `APP_PORT` | `8080`, `3000` | Internal port the app listens on — check existing apps and pick one not already in use |
 | `APP_IMAGE` | `docker.io/user/image:latest` | Full container image with tag |
-| `APP_HOSTNAME` | `myapp.watarystack.org` | Full domain for access |
+| `APP_HOSTNAME` | `{app}.watarystack.org` | Full domain for access — use pattern: `{APP_NAME}.watarystack.org` (one word + domain) |
 | `ACCESS_TYPE` | `public` or `internal` | **public** = Cloudflare Tunnel (internet-accessible); **internal** = Traefik Ingress (local network only) |
 | `DB_REQUIRED` | `yes`/`no` | Does the app need a database? |
 | `DB_TYPE` | `postgres`, `sqlite` | If yes, which database system |

--- a/apps/base/homepage/homepage-configmap.yaml
+++ b/apps/base/homepage/homepage-configmap.yaml
@@ -204,10 +204,10 @@ data:
             ping: https://hubble.watarystack.org
     - Infrastructure:
         - PiHole:
-            href: https://pihole.internal.watarystack.org/admin
+            href: https://pihole.watarystack.org/admin
             description: Network-wide DNS & Ad-Blocking
-            icon: pihole.png
-            ping: https://pihole.internal.watarystack.org
+            icon: mdi-dns
+            ping: https://pihole.watarystack.org
         - PgAdmin:
             href: https://pgadmin.watarystack.org
             description: PostgreSQL database administration

--- a/apps/staging/pihole/ingress.yaml
+++ b/apps/staging/pihole/ingress.yaml
@@ -11,10 +11,10 @@ spec:
   ingressClassName: traefik
   tls:
     - hosts:
-        - pihole.internal.watarystack.org
+        - pihole.watarystack.org
       secretName: pihole-tls
   rules:
-    - host: pihole.internal.watarystack.org
+    - host: pihole.watarystack.org
       http:
         paths:
           - path: "/"


### PR DESCRIPTION
# Phase 14: PiHole Network DNS & Ad-Blocking

## Summary

Complete implementation of network-wide DNS filtering and ad-blocking using PiHole deployed to K3s.

### Changes

**Wave 1: PiHole K3s Deployment (Plan 14-01)**
- Create PiHole base manifests (namespace, storage, deployment, service, kustomization)
- Create staging overlay with Traefik Ingress at pihole.watarystack.org
- Longhorn persistent storage for query logs and configuration

**Wave 2: Network Gateway Configuration (Plan 14-02)**  
- Configure Huawei HG659b router DHCP to use PiHole as primary DNS server
- Verify DNS resolution working from cluster
- Verify ad-blocking on multiple test domains (ads.google.com, doubleclick.net, etc)
- Create DNS flow documentation and troubleshooting runbook

**Wave 3: Grafana Dashboard & Homepage Integration (Plan 14-03)**
- Create Grafana dashboard with 5 metric panels
- Integrate PiHole into Homepage dashboard with MDI DNS icon
- Service links point to pihole.watarystack.org/admin

### Fixes in This Update
- Changed hostname from pihole.internal.watarystack.org to pihole.watarystack.org (simpler pattern)
- Fixed Homepage icon from missing pihole.png to mdi-dns (Material Design Icon)
- Updated onboarding skill documentation with hostname pattern guideline
- Restarted cert-manager, Grafana, and kube-prometheus-stack for certificate refresh

### Verification
- All 3 plans executed and verified ✓
- Phase 14 verification passed (6/6 must-haves) ✓
- ROADMAP.md and STATE.md updated ✓
- PROJECT.md evolved with phase completion ✓

🤖 Generated with Claude Code