### PR TITLE
fix(14): resolve pihole integration issues

### DIFF
--- a/apps/base/gatus/configmap.yaml
+++ b/apps/base/gatus/configmap.yaml
@@ -97,3 +97,11 @@ data:
         conditions:
           - "[STATUS] == 200"
           - "[RESPONSE_TIME] < 5000"
+
+      - name: PiHole
+        group: Infrastructure
+        url: https://pihole.watarystack.org/admin
+        interval: 60s
+        conditions:
+          - "[STATUS] == 200"
+          - "[RESPONSE_TIME] < 5000"

--- a/apps/staging/pihole/ingress.yaml
+++ b/apps/staging/pihole/ingress.yaml
@@ -17,7 +17,7 @@ spec:
     - host: pihole.watarystack.org
       http:
         paths:
-          - path: "/"
+          - path: "/admin"
             pathType: Prefix
             backend:
               service:

--- a/monitoring/configs/staging/dashboards/extra-dashboards/kustomization.yaml
+++ b/monitoring/configs/staging/dashboards/extra-dashboards/kustomization.yaml
@@ -38,3 +38,10 @@ configMapGenerator:
     options:
       labels:
         grafana_dashboard: "1"
+
+  - name: pihole-grafana-dashboard
+    files:
+      - pihole.json=pihole-dashboard.json
+    options:
+      labels:
+        grafana_dashboard: "1"

--- a/monitoring/configs/staging/dashboards/extra-dashboards/pihole-dashboard.json
+++ b/monitoring/configs/staging/dashboards/extra-dashboards/pihole-dashboard.json
@@ -1,0 +1,310 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "targets": [
+        {
+          "expr": "rate(pihole_queries_total[5m])",
+          "refId": "A",
+          "legendFormat": "Queries/sec"
+        }
+      ],
+      "title": "DNS Queries Per Second (5m rate)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "targets": [
+        {
+          "expr": "(pihole_queries_blocked_total / pihole_queries_total) * 100",
+          "refId": "A",
+          "legendFormat": "Blocked %"
+        }
+      ],
+      "title": "Ad Domains Blocked Percentage",
+      "type": "gauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 4,
+      "targets": [
+        {
+          "expr": "topk(5, pihole_clients_total)",
+          "refId": "A",
+          "legendFormat": "{{ client }}"
+        }
+      ],
+      "title": "Top 5 Querying Clients",
+      "type": "barchart"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 5,
+      "targets": [
+        {
+          "expr": "topk(5, pihole_domains_total)",
+          "refId": "A",
+          "legendFormat": "{{ domain }}"
+        }
+      ],
+      "title": "Top 5 Queried Domains",
+      "type": "barchart"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "id": 6,
+      "targets": [
+        {
+          "expr": "pihole_queries_total",
+          "refId": "A",
+          "legendFormat": "Total Queries"
+        },
+        {
+          "expr": "pihole_queries_blocked_total",
+          "refId": "B",
+          "legendFormat": "Blocked Queries"
+        }
+      ],
+      "title": "Total vs Blocked Queries (Cumulative)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 35,
+  "style": "dark",
+  "tags": ["pihole", "dns", "network"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "PiHole DNS Analytics",
+  "uid": "pihole-dns",
+  "version": 1
+}


### PR DESCRIPTION
Fixes three PiHole integration issues:

- **Ingress path**: Changed from / to /admin (PiHole admin interface requires /admin path)
- **Grafana dashboard**: Registered pihole-dashboard.json in dashboards kustomization so Grafana can load it
- **Gatus monitoring**: Added PiHole endpoint to Gatus status page for health monitoring

Closes the following issues:
- PiHole 404 when visiting pihole.watarystack.org
- Missing PiHole dashboard in Grafana
- Missing PiHole monitoring in Gatus