### PR TITLE
fix(14): register pihole dashboard and servicemonitor, update password

### DIFF
--- a/apps/staging/pihole/pihole-env-secret.yaml
+++ b/apps/staging/pihole/pihole-env-secret.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-    WEBPASSWORD: ENC[AES256_GCM,data:ADjzf6aHKuwTKyRXNWfSQULNAWQf8rpJjWb4KO+B2Z0gLJ8G3hUJgXV5Mnk=,iv:LfO5fOVB2vLFBYylu2za5VnMreqy785gffTQXTT6RIg=,tag:yihDxU/bF1AROY+h2KkjkQ==,type:str]
+    WEBPASSWORD: ENC[AES256_GCM,data://Ci60/N1M5foB34mCeSRVXY5mZgoIL3yx/hKw36/Xvi4KRg1YsQoJkK32Y=,iv:kJy7p5cYdUpMHIqP1NW9fTgAAB8RToX2NgZYdHzN3Qg=,tag:d98vS6ce+AEXyV9mCIpWxw==,type:str]
 kind: Secret
 metadata:
     creationTimestamp: null
@@ -10,13 +10,13 @@ sops:
         - recipient: age1spwc8lctzldd0ghkkls8jfvzzra7cx95r2zqq6eya84etq65wfgqy2h99p
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB4WWxwbUJqeXhpM2tMTTg4
-            ZkpJYnN0L1N5TjY4Q3l2VzkxU2ZyUnhjbTFnCnpaOXQ0VEE4ak9GVUNiMWFjTTdO
-            bUFPRkx1dGs2SW9HMW52VGZzb0hPL1UKLS0tIERQMUFZUS9mZzRINkpCNjZ1MFJV
-            MExja0VLY1d5UEFrY1YwTTVPRU1LOGMKcj0nraENTPcjBttT7E8UXNnSvzcDFMyw
-            /wGaFd2qCGryeh8UAEd9aDY/goCFsvLPCizF4wwMNysDz5ItEbSJvw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxc2E2WXZzY09RSm9YbHNx
+            eUhQZG01S2t5RTZuWURXTFptN0RldHhpVzJZCmRyY2NqYm5ON2dUWjFZN3N0Mi9P
+            eDNzR2hWbktWZFhtdXEvakNROGxYc2cKLS0tIDRncUV4dURGbnl3MURsWmw2UzNp
+            cVA3NGVzZXhMSWh0Z2FYOGdOd24zc28KWqkw8MegGqPLv5ROmUg8SYSd6o3v9GIi
+            VKm6vu03MtR1IhhrtPQr/Ri5W+UDtDM2Bcd2NDUttvywWHwvfGliug==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-11T22:06:41Z"
-    mac: ENC[AES256_GCM,data:umNj88ig56fsD5XEAJPnetAX7FF//6KZZxLc5wnZ/i1SosIhvBY6+QA+wnDl/bB1KdYH8iCSkQG5aqUVzYjvAlutdWHpaM4Mco22+WNKB16Z980CUOE6uekCHCe64hqxjAHuUXTTHt45R1gH1uEqU1rWQy74Xq4iCl9jjQUZrhk=,iv:GwPH93PwZRvGEICHIA4cGpUOI6BJvhj9wYVzx4gmsyM=,tag:K782Cw1Ab5Wrzdqar1wRyQ==,type:str]
+    lastmodified: "2026-04-11T22:13:20Z"
+    mac: ENC[AES256_GCM,data:TDsoPb0UFv64GbgnS/K1ntBas7yhZ2R8PrOPciMtDPE4gkZcrDlC76YfEm9zd98H9rXkSAt14ly4TDbswYKFD/oOcqDhyrbltB7G7+Mwm07iGsgSMb/GRNlAvknhzaX74mT4pnGMfJD0rrFLU0Enk/lfeh/RKWL9+Xy9yHdVBMI=,iv:E6yKhijbZqoIHmzoqxP+4BQ74f+hL6sKcoufmi1LWLE=,tag:1paLncR6G1o7o+ikz5tLyg==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.10.2

--- a/monitoring/configs/staging/dashboards/extra-dashboards/kustomization.yaml
+++ b/monitoring/configs/staging/dashboards/extra-dashboards/kustomization.yaml
@@ -38,3 +38,10 @@ configMapGenerator:
     options:
       labels:
         grafana_dashboard: "1"
+
+  - name: pihole-grafana-dashboard
+    files:
+      - pihole.json=pihole-dashboard.json
+    options:
+      labels:
+        grafana_dashboard: "1"

--- a/monitoring/configs/staging/kube-prometheus-stack/kustomization.yaml
+++ b/monitoring/configs/staging/kube-prometheus-stack/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - fluxcd-podmonitor.yaml
   - traefik-servicemonitor.yaml
   - traefik-metrics-service.yaml
+  - pihole-servicemonitor.yaml
   - prometheus-rbac.yaml
   - grafana-admin-secret.yaml
   - prometheus-ingress.yaml


### PR DESCRIPTION
- Encrypt newly set pihole password using pihole setpassword
- Register pihole dashboard in extra-dashboards kustomization
- Register pihole servicemonitor in kube-prometheus-stack kustomization
- Metrics will now be scraped by Prometheus and displayed in Grafana