### PR TITLE
fix(pihole): add Recreate strategy, fix domains_being_blocked metric …

### DIFF
--- a/apps/base/pihole/deployment.yaml
+++ b/apps/base/pihole/deployment.yaml
@@ -4,6 +4,8 @@ metadata:
   name: pihole
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: pihole

--- a/monitoring/configs/staging/dashboards/extra-dashboards/pihole-dashboard.json
+++ b/monitoring/configs/staging/dashboards/extra-dashboards/pihole-dashboard.json
@@ -124,7 +124,7 @@
       "id": 4,
       "targets": [
         {
-          "expr": "pihole_blocked_domains",
+          "expr": "pihole_domains_being_blocked",
           "refId": "A",
           "legendFormat": "Domains"
         }


### PR DESCRIPTION
…name

- Add strategy.type=Recreate to pihole deployment; the RWO PVC caused a RollingUpdate deadlock where the new pod could not mount the volume while the old pod held it
- Fix Grafana dashboard: pihole_blocked_domains → pihole_domains_being_blocked (corrected to match actual ekofr/pihole-exporter metric name)