### PR TITLE
fix(pihole): explicitly null rollingUpdate when strategy is Recreate

### DIFF
--- a/apps/base/pihole/deployment.yaml
+++ b/apps/base/pihole/deployment.yaml
@@ -6,6 +6,7 @@ spec:
   replicas: 1
   strategy:
     type: Recreate
+    rollingUpdate: null
   selector:
     matchLabels:
       app: pihole


### PR DESCRIPTION
Flux dry-run was failing because the existing deployment object in the cluster had rollingUpdate fields set from the prior RollingUpdate strategy. Strategic merge kept both fields, which Kubernetes rejects. Explicitly setting rollingUpdate: null clears it on apply.