### PR TITLE
fix(pihole): use JSON6902 patch to set Recreate strategy cleanly

### DIFF
--- a/apps/base/pihole/deployment.yaml
+++ b/apps/base/pihole/deployment.yaml
@@ -4,9 +4,6 @@ metadata:
   name: pihole
 spec:
   replicas: 1
-  strategy:
-    type: Recreate
-    rollingUpdate: null
   selector:
     matchLabels:
       app: pihole

--- a/apps/staging/pihole/kustomization.yaml
+++ b/apps/staging/pihole/kustomization.yaml
@@ -5,3 +5,12 @@ resources:
   - ../../base/pihole/
   - ingress.yaml
   - pihole-env-secret.yaml
+patches:
+  - patch: |
+      - op: replace
+        path: /spec/strategy
+        value:
+          type: Recreate
+    target:
+      kind: Deployment
+      name: pihole


### PR DESCRIPTION
rollingUpdate: null was preserved as a JSON null in the kustomize output, and the API server treats null as 'specified', which is forbidden with strategy type Recreate.

Move strategy out of deployment.yaml and apply it via a JSON6902 op:replace patch on /spec/strategy so the serialized manifest contains only {type: Recreate} with no rollingUpdate key at all.