### PR TITLE
fix(pihole): correct traefik middleware + dynamic node cleanup script

### DIFF
--- a/apps/staging/pihole/ingress.yaml
+++ b/apps/staging/pihole/ingress.yaml
@@ -23,7 +23,8 @@ metadata:
     gethomepage.dev/group: Infrastructure
     gethomepage.dev/icon: pi-hole.png
     gethomepage.dev/description: Network-wide ad blocking
-    traefik.ingress.kubernetes.io/middleware: pihole:pihole-redirect-root
+    gethomepage.dev/href: "https://pihole.watarystack.org/admin/login"
+    traefik.ingress.kubernetes.io/router.middlewares: pihole-pihole-redirect-root@kubernetescrd
 spec:
   ingressClassName: traefik
   tls:

--- a/infrastructure/scripts/cleanup-container-images.sh
+++ b/infrastructure/scripts/cleanup-container-images.sh
@@ -4,49 +4,73 @@
 # Recovers 50-70GB per node after months of accumulation
 #
 # Safe to run anytime - only deletes images not referenced by any pod
+# Automatically discovers cluster nodes and SSH users via kubectl
 # Usage: ./cleanup-container-images.sh
 
-set -e
-
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
-# Node IPs and SSH users (from CLAUDE.md)
-NODES=(
-  "192.168.1.115:root"           # Control-plane (local)
-  "192.168.1.89:homelab-worker1" # Worker-01
-  "192.168.1.68:homelab-worker2" # Worker-02
-)
+set -euo pipefail
 
 echo "🧹 Container Image Cleanup"
 echo "=========================="
 echo ""
-echo "Starting cleanup on $(echo ${#NODES[@]}) nodes..."
+
+# Verify kubectl access
+if ! kubectl cluster-info &>/dev/null; then
+  echo "❌ Error: Cannot reach the cluster via kubectl"
+  exit 1
+fi
+
+# Get node info: name, IP, and whether control-plane
+# Output format: <name> <ip> <is_control_plane>
+NODE_DATA=$(kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.addresses[?(@.type=="InternalIP")].address}{"\t"}{.metadata.labels.node-role\.kubernetes\.io/control-plane}{"\n"}{end}')
+
+NODE_COUNT=$(echo "$NODE_DATA" | grep -c .)
+if [ "$NODE_COUNT" -eq 0 ]; then
+  echo "❌ Error: Could not discover any cluster nodes"
+  exit 1
+fi
+
+echo "Found $NODE_COUNT node(s):"
+echo "$NODE_DATA" | while IFS=$'\t' read -r name ip role; do
+  role_label="${role:+control-plane}"
+  echo "  - $name ($ip) ${role_label}"
+done
+echo ""
 echo "This may take 2-5 minutes per node."
 echo ""
 
 SUCCESS_COUNT=0
 FAILED_COUNT=0
+FAILED_NODES=""
 
-for node_info in "${NODES[@]}"; do
-  IP="${node_info%%:*}"
-  USER="${node_info##*:}"
+while IFS=$'\t' read -r name ip is_control_plane; do
+  # Determine SSH user from node name:
+  #   control-plane nodes → root
+  #   homelab-worker-NN   → homelab-workerN (e.g. homelab-worker-01 → homelab-worker1)
+  #   anything else       → ubuntu (fallback)
+  if [ -n "$is_control_plane" ]; then
+    SSH_USER="root"
+  elif [[ "$name" =~ ^homelab-worker-([0-9]+)$ ]]; then
+    # Strip leading zeros: homelab-worker-01 → homelab-worker1
+    worker_num=$(echo "${BASH_REMATCH[1]}" | sed 's/^0*//')
+    SSH_USER="homelab-worker${worker_num}"
+  else
+    SSH_USER="ubuntu"
+  fi
 
-  # Get hostname
-  HOSTNAME=$(ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no "$USER@$IP" 'hostname' 2>/dev/null || echo "unknown")
+  echo "► Cleaning $name ($ip) as $SSH_USER..."
 
-  echo "► Cleaning $HOSTNAME ($IP)..."
-
-  if ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no "$USER@$IP" \
+  if ssh -o ConnectTimeout=10 -o StrictHostKeyChecking=no "$SSH_USER@$ip" \
     "sudo k3s crictl rmi --prune" > /dev/null 2>&1; then
     echo "  ✓ Success"
-    ((SUCCESS_COUNT++))
+    SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
   else
-    echo "  ✗ Failed (or SSH timeout)"
-    ((FAILED_COUNT++))
+    echo "  ✗ Failed (SSH error or crictl failed)"
+    FAILED_NODES="$FAILED_NODES $name($ip)"
+    FAILED_COUNT=$((FAILED_COUNT + 1))
   fi
 
   echo ""
-done
+done <<< "$NODE_DATA"
 
 echo "=========================="
 echo "Results: $SUCCESS_COUNT successful, $FAILED_COUNT failed"
@@ -56,6 +80,11 @@ if [ "$FAILED_COUNT" -eq 0 ]; then
   echo "✅ All nodes cleaned successfully!"
   exit 0
 else
-  echo "⚠️  Some nodes failed. Check SSH credentials in .env"
+  echo "⚠️  Some nodes failed:$FAILED_NODES"
+  echo ""
+  echo "Troubleshooting:"
+  echo "1. Verify SSH access: ssh <user>@<ip> 'hostname'"
+  echo "2. Verify k3s is running: ssh <user>@<ip> 'sudo k3s version'"
+  echo "3. Check SSH credentials in .env"
   exit 1
 fi


### PR DESCRIPTION
## Summary

- **Pihole redirect fix**: The previous attempt used the wrong Traefik annotation name (`traefik.ingress.kubernetes.io/middleware`) and wrong value format. Fixed to `traefik.ingress.kubernetes.io/router.middlewares: pihole-pihole-redirect-root@kubernetescrd`. The root `https://pihole.watarystack.org/` now correctly redirects to `/admin/login`.
- **Homepage href**: Added `gethomepage.dev/href: https://pihole.watarystack.org/admin/login` annotation so the homepage card links directly to the login page (regardless of the redirect).
- **Cleanup script**: Replaced hardcoded IP→user mapping with dynamic detection based on node names from `kubectl get nodes`. Also fixes a `set -e` + `((n++))` incompatibility bug.

## Test plan

- [ ] Visit `https://pihole.watarystack.org/` — should redirect to `/admin/login`
- [ ] Homepage shows single PiHole entry linking to `/admin/login`
- [ ] Run `./infrastructure/scripts/cleanup-container-images.sh` — should auto-detect all nodes and clean without hardcoded IPs

🤖 Generated with [Claude Code](https://claude.com/claude-code)