### PR TITLE
fix(headlamp): remove invalid --allowed-origins flag

### DIFF
--- a/apps/base/headlamp/deployment.yaml
+++ b/apps/base/headlamp/deployment.yaml
@@ -53,7 +53,6 @@ spec:
           args:
             - --in-cluster
             - --port=4466
-            - --allowed-origins=https://headlamp.watarystack.org
           ports:
             - name: http
               containerPort: 4466


### PR DESCRIPTION
Removes the `--allowed-origins` flag that was accidentally merged in PR #77.

This flag doesn't exist in Headlamp v0.26.0 — causes an immediate `CrashLoopBackOff` on every pod start. The deployment has been patched live via kubectl to stop the crashing, but this PR is needed so Flux reconcile doesn't revert it back to the broken state.