### PR TITLE
feat: add Wallabag (read-it-later) with Cloudflare tunnel + CloudNativePG backup

### DIFF
--- a/apps/base/homepage/homepage-configmap.yaml
+++ b/apps/base/homepage/homepage-configmap.yaml
@@ -176,6 +176,11 @@ data:
             description: Web-based file manager & sharing
             icon: filebrowser.png
             ping: https://filebrowser.watarystack.org
+        - Wallabag:
+            href: https://wallabag.watarystack.org
+            description: Self-hosted read-it-later & web archiving
+            icon: wallabag.png
+            ping: https://wallabag.watarystack.org
     - Monitoring:
         - Gatus:
             href: https://status.watarystack.org

--- a/apps/base/wallabag/configmap.yaml
+++ b/apps/base/wallabag/configmap.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: wallabag-config
+  namespace: wallabag
+data:
+  # Database configuration
+  SYMFONY__ENV__DATABASE_DRIVER: "pdo_pgsql"
+  SYMFONY__ENV__DATABASE_HOST: "wallabag-postgres-rw.wallabag.svc.cluster.local"
+  SYMFONY__ENV__DATABASE_PORT: "5432"
+  SYMFONY__ENV__DATABASE_NAME: "wallabag"
+
+  # Application configuration
+  SYMFONY__ENV__DOMAIN_NAME: "https://wallabag.watarystack.org"
+  SYMFONY__ENV__SERVER_NAME: "WataryStack Wallabag"
+
+  # Registration / confirmation
+  SYMFONY__ENV__FOSUSER_REGISTRATION: "false"
+  SYMFONY__ENV__FOSUSER_CONFIRMATION: "false"
+  SYMFONY__ENV__TWOFACTOR_AUTH: "false"
+
+  # Populate DB on first run (creates schema & default admin user)
+  POPULATE_DATABASE: "true"
+
+  # Redis disabled (single-instance homelab)
+  SYMFONY__ENV__REDIS_ENABLED: "false"

--- a/apps/base/wallabag/deployment.yaml
+++ b/apps/base/wallabag/deployment.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wallabag
+  namespace: wallabag
+  labels:
+    app: wallabag
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wallabag
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: wallabag
+    spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
+      containers:
+        - name: wallabag
+          image: wallabag/wallabag:latest
+          ports:
+            - containerPort: 80
+              name: http
+          envFrom:
+            - configMapRef:
+                name: wallabag-config
+          env:
+            - name: SYMFONY__ENV__DATABASE_USER
+              valueFrom:
+                secretKeyRef:
+                  name: wallabag-db-credentials
+                  key: username
+            - name: SYMFONY__ENV__DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: wallabag-db-credentials
+                  key: password
+            - name: SYMFONY__ENV__SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: wallabag-env-secret
+                  key: SYMFONY__ENV__SECRET
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          volumeMounts:
+            - name: wallabag-images
+              mountPath: /var/www/wallabag/web/assets/images
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+          startupProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 20
+      volumes:
+        - name: wallabag-images
+          persistentVolumeClaim:
+            claimName: wallabag-images
+      restartPolicy: Always

--- a/apps/base/wallabag/kustomization.yaml
+++ b/apps/base/wallabag/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: wallabag
+resources:
+  - namespace.yaml
+  - storage.yaml
+  - deployment.yaml
+  - service.yaml
+  - configmap.yaml
+  - network-policy.yaml

--- a/apps/base/wallabag/namespace.yaml
+++ b/apps/base/wallabag/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: wallabag

--- a/apps/base/wallabag/network-policy.yaml
+++ b/apps/base/wallabag/network-policy.yaml
@@ -1,0 +1,55 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-ingress
+  namespace: wallabag
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-same-namespace
+  namespace: wallabag
+spec:
+  podSelector: {}
+  ingress:
+  - from:
+    - podSelector: {}
+  policyTypes:
+  - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-monitoring-scraping
+  namespace: wallabag
+spec:
+  podSelector: {}
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: monitoring
+  policyTypes:
+  - Ingress
+---
+# Allow CNPG controller (cnpg-system) to manage the PostgreSQL cluster pods
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-cnpg-controller
+  namespace: wallabag
+spec:
+  podSelector:
+    matchLabels:
+      cnpg.io/podRole: instance
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: cnpg-system
+  policyTypes:
+  - Ingress

--- a/apps/base/wallabag/service.yaml
+++ b/apps/base/wallabag/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: wallabag
+  namespace: wallabag
+  labels:
+    app: wallabag
+spec:
+  selector:
+    app: wallabag
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80
+      protocol: TCP
+  type: ClusterIP

--- a/apps/base/wallabag/storage.yaml
+++ b/apps/base/wallabag/storage.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: wallabag-images
+  namespace: wallabag
+spec:
+  storageClassName: longhorn
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/apps/staging/kustomization.yaml
+++ b/apps/staging/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
   - filebrowser
   - headlamp
   - gatus
+  - wallabag

--- a/apps/staging/wallabag/cloudflare-secret.yaml
+++ b/apps/staging/wallabag/cloudflare-secret.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+data:
+    credentials.json: ENC[AES256_GCM,data:Wu4pA9BBhrB+W9goe6JpDKzzf5+wRgXsElDQ1vvXRdaKRNj65yVpBO9CeceQZ2eYtEZ1js7zbFcJikOsCsHFA1ATYpK9A7UqegFUgK2jBKrONF7y3poXN7nmckri3iFIlUry5D09JDfTE6QfGOi91sNm5xX4xxIWS/pU2WXw5gppcuJiutTi1EZgkCN2bE2AOK7h2LpZn3423K54M22Ht1V9hyyQsAECeajpn2vqh2CBFQNwUdKdd5Mwjsu19+FFRJ/PJkZ/47dtA5nzSnLKxE7DaNL2NFXVyOpTViwRGh35PZ5Ea/3t0YP9ZoQ=,iv:aJio1jxxFlWVTK3xS9JflwjHjLj2iGlzdvUcT0xdH00=,tag:+IOH2U9IVNW3X8O2nD1EZw==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: tunnel-credentials
+sops:
+    age:
+        - recipient: age1spwc8lctzldd0ghkkls8jfvzzra7cx95r2zqq6eya84etq65wfgqy2h99p
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBpZHNQNll2eURwZE44Nkh0
+            L1JUTjZmb3NUMnVmaTR1bE1Ib3FxZU1GUkVNCnAyNTQ1QWxwWUNzVkdkNGtkbnl5
+            T2ltMU5VWDhWNEgxYmFOTXErSmtSK0EKLS0tIFZTNUhtcENtbDkxdGxpcGlVQ1R4
+            ODcrNXVxQ0NwaVFSeCt0cmRBaFg4bkkKkks3niCtqeWXoeG8FZqXLtGLgbrV21BH
+            gjtvoarkJtv9YUxu3r0vyQvWcQ8RdiniShgitXDx06v329ykRZtO4g==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-01T21:51:20Z"
+    mac: ENC[AES256_GCM,data:+hznN/mjxq15oHTk81Cc4rSl+qJmeENR6LT1UWgCFAFsuisvd4E00q0SYa0tDS4rc+l5CTwv99tbPKToAvlVdp44ai4SReIEh1n78A3ZNIKoqvkNQdOD3/dz05fuS3VE8hWQPPDH3jDJ3FHE/lliY+Ossa5Z9QUgK+znS3XE/S8=,iv:pRx+hVtd37ihXXO5PmR8SCe6pIdWh9vaXTwvE8tv1aI=,tag:/ZbAiIUdFTeUU1cVdOBGgw==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2

--- a/apps/staging/wallabag/cloudflare.yaml
+++ b/apps/staging/wallabag/cloudflare.yaml
@@ -1,0 +1,71 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloudflared
+spec:
+  selector:
+    matchLabels:
+      app: cloudflared
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: cloudflared
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app: cloudflared
+      containers:
+        - name: cloudflared
+          image: cloudflare/cloudflared:latest
+          args:
+            - tunnel
+            - --config
+            - /etc/cloudflared/config/config.yaml
+            - run
+          livenessProbe:
+            httpGet:
+              path: /ready
+              port: 2000
+            failureThreshold: 1
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          volumeMounts:
+            - name: config
+              mountPath: /etc/cloudflared/config
+              readOnly: true
+            - name: creds
+              mountPath: /etc/cloudflared/creds
+              readOnly: true
+      volumes:
+        - name: creds
+          secret:
+            secretName: tunnel-credentials
+        - name: config
+          configMap:
+            name: cloudflared
+            items:
+              - key: config.yaml
+                path: config.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cloudflared
+data:
+  config.yaml: |
+    tunnel: wallabag
+
+    credentials-file: /etc/cloudflared/creds/credentials.json
+
+    metrics: 0.0.0.0:2000
+    no-autoupdate: true
+
+    ingress:
+    - hostname: wallabag.watarystack.org
+      service: http://wallabag:80
+    - service: http_status:404

--- a/apps/staging/wallabag/kustomization.yaml
+++ b/apps/staging/wallabag/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: wallabag
+resources:
+  - ../../base/wallabag/
+  - cloudflare.yaml
+  - cloudflare-secret.yaml
+  - wallabag-env-secret.yaml

--- a/apps/staging/wallabag/wallabag-env-secret.yaml
+++ b/apps/staging/wallabag/wallabag-env-secret.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+data:
+    SYMFONY__ENV__SECRET: ENC[AES256_GCM,data:S0fFav3t80UQ/ZI8scqf7EIumrjT5yTGtStxXQPhCMbYfcChB+4z5E5cJLtYF0dPdcPrqeOcssY2a+bRTRVhSFYQI9dldrD8TSoG9sRlVX6XtOqHRiSjgg==,iv:zDvGc1XEZpetCbdXqRZvZSF7QCqvxLZ5ye13iqnRHiM=,tag:V06GukjHKjHvuqX9KGUYJA==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: wallabag-env-secret
+sops:
+    age:
+        - recipient: age1spwc8lctzldd0ghkkls8jfvzzra7cx95r2zqq6eya84etq65wfgqy2h99p
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXNlVNL3lRKzltWFVjcTYz
+            TjlsN2ZuWmNNVlJxemV4K0d0ZlFuMUJkNmpJCm9TTHBsMmFRUHB1SEpYdnZUekJk
+            cFVrSXNzOFNsbFFtNWJaVUdxMThzSzQKLS0tIEM5SktlZXlHVTV6cFN0eGNVSHBj
+            U0RmS2hONlhXV2dDZFZRZ2N6ajFuN1kK7NZO9Nu79RhaMITK47pnNzBjwjEHmFk6
+            S6Cl+ch2hfUaQ57mPd7CKBclXDDUezOlCeGUiheWBsJEgREiQu/aSQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-01T21:51:20Z"
+    mac: ENC[AES256_GCM,data:IWnbkrpBe3Bf6U8AR73ibtdXADaA9NM/ju/lpwgY8KHXGK3wgiAdxTMe5EuZfsyo6OAC7zd3xJqz1AgubfGVLiixUWu36alsF6uN9ZU4Rm73/84Ks9QGFFSb2pLFY4bKdB7W6mNaGTGJr9yfRRK4+cggP6NF47zrlUfrymf7mCs=,iv:IcLJGkDenkrgmyX6A/4qCGgpKIinxh8YE0EOsPPotr8=,tag:sIg+dPG2xyKP/CFpVt7Dnw==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2

--- a/databases/staging/kustomization.yaml
+++ b/databases/staging/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 resources:
   - linkding
   - n8n
+  - wallabag

--- a/databases/staging/wallabag/backup-config.yaml
+++ b/databases/staging/wallabag/backup-config.yaml
@@ -1,0 +1,16 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: wallabag-backup
+  namespace: wallabag
+spec:
+  # Schedule: Daily at 2 AM (CNPG uses 6-field cron: sec min hour dom month dow)
+  schedule: "0 0 2 * * *"
+
+  # Trigger a backup immediately when the resource is first created
+  immediate: true
+
+  cluster:
+    name: wallabag-postgres
+
+  backupOwnerReference: cluster

--- a/databases/staging/wallabag/kustomization.yaml
+++ b/databases/staging/wallabag/kustomization.yaml
@@ -1,0 +1,31 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - secrets.yaml
+  - superuser-secret.yaml
+  - postgresql-cluster.yaml
+  - backup-config.yaml
+  - wallabag-backup-s3-secret.yaml
+  - r2-backup-configmap.yaml
+
+replacements:
+  - source:
+      kind: ConfigMap
+      name: r2-backup-config
+      fieldPath: data.endpointURL
+    targets:
+      - select:
+          kind: Cluster
+          name: wallabag-postgres
+        fieldPaths:
+          - spec.backup.barmanObjectStore.endpointURL
+  - source:
+      kind: ConfigMap
+      name: r2-backup-config
+      fieldPath: data.destinationPath
+    targets:
+      - select:
+          kind: Cluster
+          name: wallabag-postgres
+        fieldPaths:
+          - spec.backup.barmanObjectStore.destinationPath

--- a/databases/staging/wallabag/postgresql-cluster.yaml
+++ b/databases/staging/wallabag/postgresql-cluster.yaml
@@ -1,0 +1,55 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: wallabag-postgres
+  namespace: wallabag
+spec:
+  description: "PostgreSQL cluster for Wallabag application"
+  instances: 1
+
+  monitoring:
+    enabled: true
+    podMonitorEnabled: true
+
+  postgresql:
+    parameters:
+      max_connections: "100"
+      shared_buffers: "128MB"
+      effective_cache_size: "512MB"
+
+  storage:
+    size: 2Gi
+    pvcTemplate:
+      storageClassName: longhorn
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 2Gi
+
+  superuserSecret:
+    name: wallabag-superuser
+
+  bootstrap:
+    initdb:
+      database: wallabag
+      owner: wallabag
+      secret:
+        name: wallabag-db-credentials
+
+  backup:
+    barmanObjectStore:
+      destinationPath: "s3://homelab-postgres-backup/wallabag"
+      endpointURL: "https://cf504e28de7836d9611b6774cdcb303e.r2.cloudflarestorage.com"
+      s3Credentials:
+        accessKeyId:
+          name: wallabag-backup-s3-secret
+          key: ACCESS_KEY_ID
+        secretAccessKey:
+          name: wallabag-backup-s3-secret
+          key: ACCESS_KEY_SECRET
+      wal:
+        compression: gzip
+      data:
+        compression: gzip
+    retentionPolicy: "7d"

--- a/databases/staging/wallabag/r2-backup-configmap.yaml
+++ b/databases/staging/wallabag/r2-backup-configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: r2-backup-config
+  namespace: wallabag
+data:
+  endpointURL: "https://cf504e28de7836d9611b6774cdcb303e.r2.cloudflarestorage.com"
+  destinationPath: "s3://homelab-postgres-backup/wallabag"

--- a/databases/staging/wallabag/secrets.yaml
+++ b/databases/staging/wallabag/secrets.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+data:
+    password: ENC[AES256_GCM,data:bB+86mw9Iyh3fbagxZt08pi8yR9V7O79mQT634rMb5egcSDScnsRIj2D7tI=,iv:iSY3b7AHlmpx1fciUwur6UPHgjERinJ/Ed7Uv+au2bo=,tag:qon7AK1BiO4ndCbGBT9J+g==,type:str]
+    username: ENC[AES256_GCM,data:m3cwRoMgbp2noKUU,iv:Jq9BGAudnjaY4zrYw2s/lawNN+xBC0iOTodZVy/aSv4=,tag:6ZN4icHhemOdKoIbFQJwyw==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: wallabag-db-credentials
+type: kubernetes.io/basic-auth
+sops:
+    age:
+        - recipient: age1spwc8lctzldd0ghkkls8jfvzzra7cx95r2zqq6eya84etq65wfgqy2h99p
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWTU0yNmhFcWxTR1Q0aElW
+            cmowbE9sOEc5V1dQS0dTcVljbUpsTTdvelNrCjQ4RnhzZnJ0SkNGNDVZYWIvQXgr
+            d2YzUlFFbXF1WTZacHl2OE9nUmhqcjgKLS0tIGhzRjNDRUtFeXM1RTcwV0pZYlBM
+            enllSTVua29uOGRmZ3BzUkpLWXhkcFUKqUnYCnpyDJ2c3f+4enX+yGGJM3GKx9Pf
+            EVLJFZMFIuys5bEYIjQHPRiOMTHUTY9dqGJI25Vwz2Y5VaPEvioGjQ==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-01T21:52:50Z"
+    mac: ENC[AES256_GCM,data:kmjLcQNBKuwAQRCsRnLAlFS8nLNC2LVh6T9wom3j8dgT58eWe70ZYIYt4RW/BOlIVRCCaMvrMmqQMfVXlcr5FNcijKjZokJruJQ4S1MKQkL4fJmLM8Wj5YYPuVPab1l/ekumCfdC6+FtVMUMbIuPgwwUU8H1lzDwtlYvE15htlE=,iv:NYH11j2Wd2tMp0Po9hwSrK+yx5hdNqwql0ETjm+iNOk=,tag:CKFpbH11UMXtKHKyZ+lJVA==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2

--- a/databases/staging/wallabag/superuser-secret.yaml
+++ b/databases/staging/wallabag/superuser-secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+data:
+    password: ENC[AES256_GCM,data:WFjVper4MgghmWrJDlKF7BAXrNul2cv0LnIZGrWEPIx4O7prQ0WfrpjdqIo=,iv:RaNb24pAwM789HBAVfMBuZoiC0KxLj3z8tredoyr/bc=,tag:eSheXQyDvK98YfOdZ5fhxA==,type:str]
+    username: ENC[AES256_GCM,data:NwebC9qckVsUN4ZN,iv:clk46fOMEMKxUiLhNo2AAtj3tLlCrQqJK72a9FSlAl0=,tag:D3ZoDm9BGuGyaI5Cz7pXkQ==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: wallabag-superuser
+sops:
+    age:
+        - recipient: age1spwc8lctzldd0ghkkls8jfvzzra7cx95r2zqq6eya84etq65wfgqy2h99p
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxWmRmUXJLOXRmcGVseDh1
+            SUZvd01KRi9yYks2WGZXT0dmVWMzMjcrUG4wCi9LYWFldVl4RDdrYkZKYjNyZXg4
+            Wm5SQWVxc0VYK21UdFFUYzNBWHc5Q1UKLS0tIHN1UWVHdk5JWU5jeExPSEI1V3VL
+            UUVEc3liWno4bEVReEpQWlZGdkZ2RVEKcXh6PayfN2Sc1tyM8Pl+oyxGV/PNJuqH
+            iviDDi4bhuqjQ2I2e5Ge3EWK3F29E/fBDtIn2RLZVsD3CmXt2Q4m4g==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-01T21:52:50Z"
+    mac: ENC[AES256_GCM,data:UTn3MAapMGFqJkJqKtNGjswMKs03Bm33ZYYyIh/8sVKGc5gsNHky9LemTIMewGeUa2cteyV4R87rMwU6RL22ldAtQGj+6NKimr2TjJnVP/ndirpZ8LIeWDXvlkQhIiKGsZZF5rmRMlEN3J/8xz4Whvuuhtd1Bz8hsh4FYOBQy+M=,iv:Y4fcDl7ZZsLnz2RD1caFB1mvjdEBCX9F4JA5FAm5ZXY=,tag:kOkvmttcMoPy2HDKjrI9eQ==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2

--- a/databases/staging/wallabag/wallabag-backup-s3-secret.yaml
+++ b/databases/staging/wallabag/wallabag-backup-s3-secret.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+data:
+    ACCESS_KEY_ID: ENC[AES256_GCM,data:Te5ZO/NvzjIkQ+6amhIbMQxtzQZyNxYl4aQr34snQDJR+VqFX28IDdD2+Pc=,iv:eI2xFmmlyauoZ2bz903FeC90kG23OSEaoLrh+3q6Bgo=,tag:ji+oegUY2OOg56iNNjdhSw==,type:str]
+    ACCESS_KEY_SECRET: ENC[AES256_GCM,data:VEVTp2caknBRA0LB7eUkmk9v/dPUdYOlqiD0XAVdTefx25nKJzd4h3Y9OdIRaxiYLVDnz1M4oHGHQH6uInzzSc8zmYLBZTjmAeLAi72dgGXqXwTvmR473Q==,iv:htxu9n1dVHPcTkPrIpIOxWfj1EDTKrH1iEQXa5q1unI=,tag:ngLbBcSb4sz6TbTlH+9AUg==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: wallabag-backup-s3-secret
+sops:
+    age:
+        - recipient: age1spwc8lctzldd0ghkkls8jfvzzra7cx95r2zqq6eya84etq65wfgqy2h99p
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxRW1DUE9hREVOcndiNkl0
+            aG4zSmQ3SFhHbllFZFE3b1h1Vkt1b011a0VNCkpqMFM0Q1RiVVBwcHVGMlVtdjNC
+            WkJXakxXL2NDOVg1clJsa2ZiRkVSQlkKLS0tIDh3NmdWR3ZWUmdqTHFFVlN3SEE3
+            QlZHNk1TMXFQcXBhcWNJK2xVYVZyNkUK7Ox08izxMepE2jWymIAauyMxTpOhRopj
+            BefzXDMMIqoFqFVgiIC4BTmRHD4zCq645xw0tj28G8gz0H/KsgsveA==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2026-05-01T21:52:50Z"
+    mac: ENC[AES256_GCM,data:wJJTx4GUI5LVawNoDH8OLPKB6KbnCKNh2Yx4IT/gtXsZbDZO7y9UMiqz5PmHXM9WzINEuykeakyftYz0Nty2AJTekcYksQndkR3cnI0zepQ9mUSghDx4dlzsDP29SM6B2sNIFBeCh5f72Sfti4HBzGenJQNqMuIg6BOkU35pPjc=,iv:KsfvUOR5ZtzjuJU2JHUnoW/lJUCcoeReRBQqLqLIVLM=,tag:PZNVzyspZ8X8G6erKGC7og==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.10.2


### PR DESCRIPTION
## What

Adds Wallabag self-hosted read-it-later service to the HomeLab.

## Architecture

- Image: wallabag/wallabag:latest (port 80)
- Hostname: wallabag.watarystack.org
- Access: Public via Cloudflare Tunnel (no Ingress/Traefik)
- Database: CloudNativePG PostgreSQL cluster in wallabag namespace
- Backup: Daily at 2 AM to Cloudflare R2 s3://homelab-postgres-backup/wallabag
- Storage: 5Gi Longhorn PVC for saved article images

## Files created

- apps/base/wallabag/ - namespace, deployment, service, storage, configmap, network-policy
- apps/staging/wallabag/ - cloudflare tunnel deployment + SOPS-encrypted secrets
- databases/staging/wallabag/ - CNPG cluster, scheduled backup, R2 configmap + encrypted secrets

## Secrets (SOPS-encrypted, safe in Git)

All secrets encrypted with age key from .sops.yaml:
- cloudflare-secret.yaml - Cloudflare tunnel credentials JSON
- wallabag-env-secret.yaml - Symfony app secret
- secrets.yaml - DB user credentials
- superuser-secret.yaml - DB superuser credentials
- wallabag-backup-s3-secret.yaml - R2 access key + secret

## Pre-merge checklist

- [ ] Add DNS CNAME in Cloudflare (required before traffic works)
- [ ] Verify manifests look correct
- [ ] Merge - FluxCD will deploy automatically

## Cloudflare DNS to add

Go to Cloudflare dashboard > watarystack.org > DNS > Add record:

Type: CNAME
Name: wallabag
Target: 896ef620-5fd6-46e1-bfd0-61276d63b9cc.cfargotunnel.com
Proxy status: Proxied (orange cloud)

## Post-merge monitoring

kubectl get pods -n wallabag
kubectl logs -f deployment/wallabag -n wallabag
kubectl logs -f deployment/cloudflared -n wallabag
