### PR TITLE
fix(wallabag): add namespace to databases kustomization

### DIFF
--- a/databases/staging/wallabag/kustomization.yaml
+++ b/databases/staging/wallabag/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: wallabag
 resources:
   - secrets.yaml
   - superuser-secret.yaml


### PR DESCRIPTION
Fixes flux error: Secret/wallabag-backup-s3-secret namespace not specified. The databases/staging/wallabag/kustomization.yaml was missing namespace: wallabag at the top level, so all secrets were applied without a namespace and the server rejected them. This is a hotfix for the broken flux databases kustomization.