### PR TITLE
fix(wallabag): comment out monitoring fields not in CNPG schema

### DIFF
--- a/databases/staging/wallabag/postgresql-cluster.yaml
+++ b/databases/staging/wallabag/postgresql-cluster.yaml
@@ -7,9 +7,9 @@ spec:
   description: "PostgreSQL cluster for Wallabag application"
   instances: 1
 
-  monitoring:
-    enabled: true
-    podMonitorEnabled: true
+  # monitoring:
+  #   enabled: true
+  #   podMonitorEnabled: true
 
   postgresql:
     parameters:


### PR DESCRIPTION
Fixes flux dry-run error: .spec.monitoring.enabled field not declared in schema. The installed CNPG version does not support this field. Commented out to match n8n and linkding cluster pattern.