### PR TITLE
fix(wallabag): create namespace in databases kustomization

### DIFF
--- a/databases/staging/wallabag/kustomization.yaml
+++ b/databases/staging/wallabag/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: wallabag
 resources:
+  - namespace.yaml
   - secrets.yaml
   - superuser-secret.yaml
   - postgresql-cluster.yaml

--- a/databases/staging/wallabag/namespace.yaml
+++ b/databases/staging/wallabag/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: wallabag


### PR DESCRIPTION
Adds namespace.yaml to databases/staging/wallabag/ so the wallabag namespace is created before secrets and CNPG cluster resources are applied. Previously namespace was only in apps kustomization, creating a circular dependency (apps depends on databases, databases needs the namespace).