### PR TITLE
fix(wallabag): store admin password in SOPS secret

### DIFF
--- a/apps/base/wallabag/deployment.yaml
+++ b/apps/base/wallabag/deployment.yaml
@@ -46,6 +46,8 @@ spec:
               else
                 echo "Schema already exists — skipping install."
               fi
+              echo "Setting admin password..."
+              su -c "php bin/console fos:user:change-password wallabag '$WALLABAG_ADMIN_PASSWORD' --env=prod" -s /bin/sh nobody
           envFrom:
             - configMapRef:
                 name: wallabag-config
@@ -65,6 +67,11 @@ spec:
                 secretKeyRef:
                   name: wallabag-env-secret
                   key: SYMFONY__ENV__SECRET
+            - name: WALLABAG_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: wallabag-env-secret
+                  key: WALLABAG_ADMIN_PASSWORD
       containers:
         - name: wallabag
           image: wallabag/wallabag:latest

--- a/apps/staging/wallabag/wallabag-env-secret.yaml
+++ b/apps/staging/wallabag/wallabag-env-secret.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 data:
-    SYMFONY__ENV__SECRET: ENC[AES256_GCM,data:S0fFav3t80UQ/ZI8scqf7EIumrjT5yTGtStxXQPhCMbYfcChB+4z5E5cJLtYF0dPdcPrqeOcssY2a+bRTRVhSFYQI9dldrD8TSoG9sRlVX6XtOqHRiSjgg==,iv:zDvGc1XEZpetCbdXqRZvZSF7QCqvxLZ5ye13iqnRHiM=,tag:V06GukjHKjHvuqX9KGUYJA==,type:str]
+    SYMFONY__ENV__SECRET: ENC[AES256_GCM,data:h3NT1hnO7rY+x3WyrU9FBuKKwgt8HiaSu/wDGo3InUkaDUJynElfDOnQMjMasQ1FdGEcMHL1tP/lBVSlRMRUOk265oT+4BgdE/5hD+9cx9GAyOR8AfvQrQ==,iv:Or53D18JagSE/h4X834OB6/jvftJx1/K/TSq5FLRH+I=,tag:yo19KvMO8qBLwwRCvfZIrg==,type:str]
+    WALLABAG_ADMIN_PASSWORD: ENC[AES256_GCM,data:yhkA/yrBNiXHaGZFsDZezU4T7JZN+3+yPc7IAk6DfLbJrNl5IK/iXA==,iv:62iC3wa7WSFaxHMaaoMygM/gXFE95jCbiQM4m7wNjRA=,tag:n5braZpjLZ+4HOXGdYZSqQ==,type:str]
 kind: Secret
 metadata:
     creationTimestamp: null
@@ -10,13 +11,13 @@ sops:
         - recipient: age1spwc8lctzldd0ghkkls8jfvzzra7cx95r2zqq6eya84etq65wfgqy2h99p
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBXNlVNL3lRKzltWFVjcTYz
-            TjlsN2ZuWmNNVlJxemV4K0d0ZlFuMUJkNmpJCm9TTHBsMmFRUHB1SEpYdnZUekJk
-            cFVrSXNzOFNsbFFtNWJaVUdxMThzSzQKLS0tIEM5SktlZXlHVTV6cFN0eGNVSHBj
-            U0RmS2hONlhXV2dDZFZRZ2N6ajFuN1kK7NZO9Nu79RhaMITK47pnNzBjwjEHmFk6
-            S6Cl+ch2hfUaQ57mPd7CKBclXDDUezOlCeGUiheWBsJEgREiQu/aSQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBROWNOVzZsLzdIUmkrT1Rj
+            bkd4NERHT0h2RTFUM0U4NTZqTkFjMEcxL0hrCktaUVhHeUJKZ0R4alNvYS9aUnVM
+            RGNsQk84VmpRUDNCRjJXVVRUTkoyeUEKLS0tIEh1ZnJldWdONzc5bHFDcUlPbWFR
+            cTA4WEVUMENsSDRROEs5VVBCeXJGZk0KVZP643K3OdfHGPvIXUaSll4dCa+6f6Xk
+            Z7aAo/JKCKmrHVkyhsq7R6HG12XmdB9T6DJdv/erXwY0Iav6A+wyLQ==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-05-01T21:51:20Z"
-    mac: ENC[AES256_GCM,data:IWnbkrpBe3Bf6U8AR73ibtdXADaA9NM/ju/lpwgY8KHXGK3wgiAdxTMe5EuZfsyo6OAC7zd3xJqz1AgubfGVLiixUWu36alsF6uN9ZU4Rm73/84Ks9QGFFSb2pLFY4bKdB7W6mNaGTGJr9yfRRK4+cggP6NF47zrlUfrymf7mCs=,iv:IcLJGkDenkrgmyX6A/4qCGgpKIinxh8YE0EOsPPotr8=,tag:sIg+dPG2xyKP/CFpVt7Dnw==,type:str]
+    lastmodified: "2026-05-01T22:30:56Z"
+    mac: ENC[AES256_GCM,data:460ZvPgSTvJNz8lzKKNgRq6mZf3DVEynIQNimDxoSL9Nf/KjdMzsgW/TbKv73aEHbcrQfTGx+Rl+iGFkj0Ea0xMsQ7FfgfQRJengSN7dg0pGfoLXKLXvKD2G/g29mlg0JpkkIasrS8O+NXRe7N6Fwm+ljW2tuRjCXheRvjEXdmA=,iv:8SHtHAEMactswEQ2NuWrfQJJaJJz6yyI4yywDuynTkM=,tag:kv8jg7qKPKSuA+73sxjYqg==,type:str]
     encrypted_regex: ^(data|stringData)$
     version: 3.10.2


### PR DESCRIPTION
The default wallabag:install creates admin user with wallabag/wallabag credentials. This PR:
- Adds WALLABAG_ADMIN_PASSWORD to the SOPS-encrypted wallabag-env-secret
- Updates the init container to run fos:user:change-password on every pod start (idempotent), ensuring the admin password is always sourced from the encrypted secret

To retrieve your admin password: `kubectl get secret -n wallabag wallabag-env-secret -o jsonpath='{.data.WALLABAG_ADMIN_PASSWORD}' | base64 -d`